### PR TITLE
Fix crash when handling a Collection with Bundled Assets

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -78,12 +78,12 @@ class stepURL(QDialog):
 		stepVersion(self.parent()).exec()
 
 class stepVersion(QDialog):
-    
+	
 	def __init__(self, parent=None):
 		super().__init__(parent)
 		self.setWindowTitle("NXM Collection Downloader - Select Revision")
 		self.setMinimumWidth(300)
-    
+	
 		layout = QVBoxLayout()
 
 		collectionData = fetchInfo(var.uri)
@@ -406,24 +406,30 @@ class stepBundled(QDialog):
 	def __init__(self, parent=None):
 		super().__init__(parent)
 
-		self.setWindowTitle("NXM Collection Downloader - Bundled Mods")
+		self.setWindowTitle("NXM Collection Downloader - Bundled Mods Warning")
 		self.setMinimumWidth(300)
 
 		layout = QVBoxLayout()
-		label = QLabel("Included 'Bundled' mods:")
+		explanation = QLabel(
+"""
+Bundled assets are currently unsupported as there are no public APIs for retreiving them. 
+They can only be retreived with the Vortex client, and are listed here for your information.
+""")
+		label = QLabel("The following bundled assets will NOT be installed:")
+		label.setStyleSheet("color: red; font-weight: bold;")
+		layout.addWidget(explanation)
 		layout.addWidget(label)
-
 		self.modlist = QListWidget()
 		self.modlist.setSelectionMode(QAbstractItemView.SelectionMode.MultiSelection)
 		self.modlist.setAlternatingRowColors(True)
 		for mod in var.bundledMods:
-			item = QListWidgetItem(f"{mod['file']['mod']['name']} by {mod['file']['mod']['author']}")
+			item = QListWidgetItem(f"{mod['name']}")
 			item.setData(Qt.ItemDataRole.UserRole, mod)
 			self.modlist.addItem(item)
 		self.modlist.setMinimumHeight(200)
 		layout.addWidget(self.modlist)
 
-		self.submit_btn = QPushButton("Next")
+		self.submit_btn = QPushButton("Acknowledge")
 		self.submit_btn.clicked.connect(self.submit)
 		layout.addWidget(self.submit_btn)
 


### PR DESCRIPTION
Bundled assets do not have the same structure as mods in the API, leading to a `keyError` crash. This change simply updates the display routine to index into the correct field for bundles and adds clarifying help text to inform the user that the listed items will not be included.

Changes tested using [VeryLastKiss's New New Vegas](https://www.nexusmods.com/games/newvegas/collections/jscbqj) collection, which includes several bundled resources.

Example of the actual format of bundled assets returned by the API: 
```json
{'id': 628058, 'name': 'New Vegas Animation Overhaul (NVAO) - Throwverhaul (Throwing)', 'resourceType': 'bundle', 'resourceUrl': None}
```
is
Example log output of crash condition:
```
[2025-12-01 21:38:40.712 E] Traceback (most recent call last):
[2025-12-01 21:38:40.712 E]   File "Z:\home/jake/Games/mod-organizer-2-newvegas/modorganizer2/plugins\modorganizer2-nxm-collection-dl\gui.py", line 401, in submit
[2025-12-01 21:38:40.712 E]     stepBundled(self.parent()).exec()
[2025-12-01 21:38:40.712 E]     ^^^^^^^^^^^^^^^^^^^^^^^^^^
[2025-12-01 21:38:40.712 E]   File "Z:\home/jake/Games/mod-organizer-2-newvegas/modorganizer2/plugins\modorganizer2-nxm-collection-dl\gui.py", line 420, in __init__
[2025-12-01 21:38:40.713 E]     item = QListWidgetItem(f"{mod['file']['mod']['name']} by {mod['file']['mod']['author']}")
[2025-12-01 21:38:40.713 E]                               ~~~^^^^^^^^
[2025-12-01 21:38:40.713 E] KeyError: 'file'
```