### PR TITLE
Fix: save collection metadata in direct download path

### DIFF
--- a/__meta__.py
+++ b/__meta__.py
@@ -22,7 +22,6 @@ class DownloadCollectionTool(mobase.IPluginTool):
 
     def init(self, organizer: mobase.IOrganizer):
         self._organizer = organizer
-        qDebug("[NXMColDL] Initializing Download Collection plugin")
         try:
             import sys as _sys
 
@@ -62,8 +61,9 @@ class DownloadCollectionTool(mobase.IPluginTool):
         self._parent = widget
 
     def display(self) -> None:
-        dlg = getattr(self, "_stepURL", None) or stepURL()
-        dlg.exec()
+        if not hasattr(self, "_stepURL") or self._stepURL is None:
+            self._stepURL = stepURL(getattr(self, "_parent", None))
+        self._stepURL.exec()
 
     def settings(self):
         return [
@@ -89,7 +89,7 @@ class DownloadCollectionTool(mobase.IPluginTool):
     def downloadMod(self, modInfo: dict):
         modID = int(modInfo["file"]["mod"]["modId"])
         fileID = int(modInfo["file"]["fileId"])
-        qDebug(f"[NXMColDL] Downloading mod {modID} file {fileID}")
+        qDebug(f"Downloading mod {modID} file {fileID}")
         return self._organizer.downloadManager().startDownloadNexusFile(modID, fileID)
 
 
@@ -102,7 +102,6 @@ class InstallCollectionTool(mobase.IPluginTool):
 
     def init(self, organizer: mobase.IOrganizer):
         self._organizer = organizer
-        qDebug("[NXMColDL] Initializing Install Collection plugin")
         try:
             import sys
 
@@ -142,8 +141,9 @@ class InstallCollectionTool(mobase.IPluginTool):
         self._parent = widget
 
     def display(self) -> None:
-        dlg = getattr(self, "_stepSelectCollection", None) or stepSelectCollection()
-        dlg.exec()
+        if not hasattr(self, "_stepSelectCollection") or self._stepSelectCollection is None:
+            self._stepSelectCollection = stepSelectCollection(getattr(self, "_parent", None))
+        self._stepSelectCollection.exec()
 
     def settings(self):
         return [mobase.PluginSetting("enabled", "Enable", True)]

--- a/download.py
+++ b/download.py
@@ -39,14 +39,12 @@ class ModInfoWorker(QObject):
             else:
                 self.finished.emit(mods)
         except Exception as e:
-            qDebug(f"[NXMColDL] Error fetching mod info: {str(e)}")
             self.error.emit(str(e))
 
 
 class stepURL(QDialog):
     def __init__(self, parent=None):
         super().__init__(parent)
-        qDebug("[NXMColDL] Initializing stepURL dialog")
         self.setWindowTitle("NXM Collection Downloader - Enter URL")
         self.setMinimumWidth(400)
 
@@ -87,7 +85,6 @@ class stepURL(QDialog):
     def submit(self):
         matched = self.get_url()
         if not matched:
-            qDebug("[NXMColDL] stepURL: URL validation failed")
             QMessageBox.critical(
                 self,
                 "Error",
@@ -105,14 +102,12 @@ class stepURL(QDialog):
 class stepVersion(QDialog):
     def __init__(self, parent=None):
         super().__init__(parent)
-        qDebug("[NXMColDL] Initializing stepVersion dialog")
         self.setWindowTitle("NXM Collection Downloader - Select Revision")
         self.setMinimumWidth(300)
         self.network_manager = None
 
         layout = QVBoxLayout()
 
-        qDebug("[NXMColDL] Fetching collection info...")
         collectionData = fetchInfo(var.uri)
 
         qDebug(f"[NXMColDL] Collection Info: {var.cleanJson(collectionData)}")
@@ -171,51 +166,29 @@ class stepVersion(QDialog):
         self.setLayout(layout)
 
     def getList(self):
-        qDebug("[NXMColDL] stepVersion: Fetching revisions list")
         revisions = fetchRevisions(var.uri)
         if revisions:
-            revision_list = revisions.get("collection", {}).get("revisions", [])
-            qDebug(
-                f"[NXMColDL] stepVersion: Adding {len(revision_list)} revisions to dropdown"
-            )
-            for data in revision_list:
+            for data in revisions.get("collection", {}).get("revisions", []):
                 created = (
                     data.get("createdAt", "").split("T")[0]
                     if data.get("createdAt")
                     else ""
                 )
-                revision_num = data.get("revisionNumber", "?")
-                self.dropdown.addItem(f"Revision {revision_num} ({created})")
-                qDebug(
-                    f"[NXMColDL] stepVersion: Added revision {revision_num} created on {created}"
+                self.dropdown.addItem(
+                    f"Revision {data.get('revisionNumber', '?')} ({created})"
                 )
-        else:
-            qDebug("[NXMColDL] stepVersion: No revisions found or fetch failed")
 
     def submit(self):
         revision_text = self.dropdown.currentText()
-        if not revision_text:
-            qDebug("[NXMColDL] No revision selected")
-            return
-
-        try:
-            revision_str = revision_text.replace("Revision ", "").split(" (")[0].strip()
-            if not revision_str or revision_str == "?":
-                qDebug(f"[NXMColDL] Invalid revision text: {revision_text}")
-                return
-            var.revision = int(revision_str)
-            qDebug(f"[NXMColDL] Selected Revision: {var.revision}")
-            self.close()
-            stepModCount(self.parent()).exec()
-        except (ValueError, IndexError) as e:
-            qDebug(f"[NXMColDL] Failed to parse revision from '{revision_text}': {e}")
-            return
+        var.revision = int(revision_text.replace("Revision ", "").split(" (")[0])
+        qDebug(f"[NXMColDL] Selected Revision: {var.revision}")
+        self.close()
+        stepModCount(self.parent()).exec()
 
 
 class stepModCount(QDialog):
     def __init__(self, parent=None):
         super().__init__(parent)
-        qDebug("[NXMColDL] Initializing stepModCount dialog")
         self.setWindowTitle("NXM Collection Downloader - Mod Count")
         self.setMinimumWidth(300)
 
@@ -260,7 +233,6 @@ class stepModCount(QDialog):
         self._worker.finished.connect(self._worker.deleteLater)
         self._thread.finished.connect(self._thread.deleteLater)
         self._thread.start()
-        qDebug("[NXMColDL] stepModCount: Worker thread started")
 
     def _on_mods_error(self, err):
         qDebug(f"[NXMColDL] Error fetching mods: {err}")
@@ -271,7 +243,6 @@ class stepModCount(QDialog):
         self.bundledLabel.setText("Error loading bundled resources")
 
     def _on_mods_fetched(self, mods):
-        qDebug("[NXMColDL] stepModCount: Processing fetched mod data")
         qDebug(f"[NXMColDL] Mods Info: {var.cleanJson(mods)}")
         for mod in mods.get("collectionRevision", {}).get("modFiles", []):
             if not mod.get("optional"):
@@ -293,10 +264,6 @@ class stepModCount(QDialog):
         externalCount = len(var.externalMods)
         bundledCount = len(var.bundledMods)
 
-        qDebug(
-            f"[NXMColDL] stepModCount: Totals - Essential: {essentialCount}, Optional: {optionalCount}, External: {externalCount}, Bundled: {bundledCount}"
-        )
-
         self.essentialLabel.setText(f"{essentialCount} essential mods")
         self.optionalLabel.setText(f"{optionalCount} optional mods")
         self.externalLabel.setText(f"{externalCount} external resources")
@@ -305,24 +272,16 @@ class stepModCount(QDialog):
         self.submit_btn.setEnabled(True)
 
     def submit(self):
-        qDebug(
-            "[NXMColDL] stepModCount: Proceeding to next dialog based on available mod types"
-        )
         self.close()
         if var.essentialMods:
-            qDebug("[NXMColDL] stepModCount: Opening stepEssential")
             stepEssential(self.parent()).exec()
         elif var.optionalMods:
-            qDebug("[NXMColDL] stepModCount: Opening stepOptional")
             stepOptional(self.parent()).exec()
         elif var.externalMods:
-            qDebug("[NXMColDL] stepModCount: Opening stepExternal")
             stepExternal(self.parent()).exec()
         elif var.bundledMods:
-            qDebug("[NXMColDL] stepModCount: Opening stepBundled")
             stepBundled(self.parent()).exec()
         else:
-            qDebug("[NXMColDL] stepModCount: No mods found, opening stepSummary")
             stepSummary(self.parent()).exec()
 
 
@@ -610,12 +569,10 @@ class stepDownloadProgress(QDialog):
         if not self.is_tracking:
             return
 
-        qDebug(f"[NXMColDL Progress] Download completed: ID {download_id}")
         self.completed_count += 1
         self.update_progress()
 
         if self.completed_count >= self.total_mods:
-            qDebug("[NXMColDL Progress] All downloads completed")
             self.is_tracking = False
 
     def on_download_failed(self, download_id):
@@ -623,15 +580,11 @@ class stepDownloadProgress(QDialog):
         if not self.is_tracking:
             return
 
-        qDebug(f"[NXMColDL Progress] Download failed: ID {download_id}")
         self.failed_count += 1
         self.completed_count += 1
         self.update_progress()
 
         if self.completed_count >= self.total_mods:
-            qDebug(
-                f"[NXMColDL Progress] Download tracking complete. {self.failed_count} failed."
-            )
             self.is_tracking = False
 
     def on_download_removed(self, download_id):
@@ -682,9 +635,6 @@ class stepDownload(QDialog):
 
             if var.openModWebsites:
                 # User chose to open websites instead of downloading
-                qDebug(
-                    "[NXMColDL] stepDownload: Opening mod websites mode (user is non-Premium or chose this option)"
-                )
                 for mod in var.essentialMods + var.chosenOptional:
                     mod_id = mod["file"]["mod"]["modId"]
                     mod_url = f"https://www.nexusmods.com/{var.game}/mods/{mod_id}"
@@ -692,21 +642,41 @@ class stepDownload(QDialog):
                 self.label.setText(
                     f"Ready to open {len(self.mod_urls_to_open)} mod website(s) in batches."
                 )
+
+                # Save collection metadata for later installation
+                try:
+                    from pathlib import Path
+                    base_path = Path(plugin_instance._organizer.basePath())
+                    metadata_file = var.saveCollectionMetadata(base_path)
+                    qDebug(f"[NXMColDL] Collection metadata saved to: {metadata_file}")
+                except (ValueError, IOError) as e:
+                    qDebug(f"[NXMColDL] Failed to save collection metadata: {e}")
+                    QMessageBox.warning(
+                        self,
+                        "Warning",
+                        f"Failed to save collection metadata:\n\n{e}\n\n"
+                        "You will not be able to install this collection automatically later.",
+                    )
             else:
                 # Queue downloads and show progress tracker
-                qDebug(
-                    "[NXMColDL] stepDownload: Queueing downloads via MO2 download manager"
-                )
                 mods_to_download = var.essentialMods + var.chosenOptional
-                qDebug(f"[NXMColDL] Queueing {len(mods_to_download)} downloads")
                 for mod in mods_to_download:
-                    mod_id = mod["file"]["mod"]["modId"]
-                    file_id = mod["file"]["fileId"]
-                    mod_name = mod["file"]["mod"]["name"]
-                    qDebug(
-                        f"[NXMColDL] stepDownload: Queueing download - ModID: {mod_id}, FileID: {file_id}, Name: {mod_name}"
-                    )
                     plugin_instance.downloadMod(mod)
+
+                # Save collection metadata for later installation
+                try:
+                    from pathlib import Path
+                    base_path = Path(plugin_instance._organizer.basePath())
+                    metadata_file = var.saveCollectionMetadata(base_path)
+                    qDebug(f"[NXMColDL] Collection metadata saved to: {metadata_file}")
+                except (ValueError, IOError) as e:
+                    qDebug(f"[NXMColDL] Failed to save collection metadata: {e}")
+                    QMessageBox.warning(
+                        self,
+                        "Warning",
+                        f"Failed to save collection metadata:\n\n{e}\n\n"
+                        "You will not be able to install this collection automatically later.",
+                    )
 
                 self.close()
                 progress_dialog = stepDownloadProgress(
@@ -715,21 +685,6 @@ class stepDownload(QDialog):
                 progress_dialog.exec()
                 return
 
-            # Save collection metadata for later installation
-            try:
-                from pathlib import Path
-
-                base_path = Path(plugin_instance._organizer.basePath())
-                metadata_file = var.saveCollectionMetadata(base_path)
-                qDebug(f"[NXMColDL] Collection metadata saved to: {metadata_file}")
-            except (ValueError, IOError) as e:
-                qDebug(f"[NXMColDL] Failed to save collection metadata: {e}")
-                QMessageBox.warning(
-                    self,
-                    "Warning",
-                    f"Failed to save collection metadata:\n\n{e}\n\n"
-                    "You will not be able to install this collection automatically later.",
-                )
         else:
             qDebug(
                 "[NXMColDL] downloadMod called without active plugin instance; Aborting"


### PR DESCRIPTION
saveCollectionMetadata was only being called in the openModWebsites branch, meaning Premium users using direct downloads never had their collection metadata saved. This caused the Install Downloaded Collection tool to find no collections and show a blank window.

Also fixed display() methods in IPluginTool subclasses to be defensive about _stepURL and _stepSelectCollection not being initialized yet, preventing a pure virtual function call crash on MO2 2.5.2."

I still get a blank window after the downloads are complete but after closing that, you can now select a Collection to install from the Tools -->NXM Collections --> Install Downloaded Collections menu item. The .json file is saved correctly now in the Wine prefix path inside Steam's Proton compatdata folder. For example: /SteamLibrary/steamapps/compatdata/489830/pfx/drive_c/users/steamuser/AppData/Local/ModOrganizer/Skyrim Special Edition/collections/skyrimspecialedition/