### PR TITLE
Improve collection download and install flow

### DIFF
--- a/__meta__.py
+++ b/__meta__.py
@@ -146,7 +146,34 @@ class InstallCollectionTool(mobase.IPluginTool):
         dlg.exec()
 
     def settings(self):
-        return [mobase.PluginSetting("enabled", "Enable", True)]
+        return [
+            mobase.PluginSetting("enabled", "Enable", True),
+            mobase.PluginSetting(
+                "auto_accept_quick_install",
+                "Automatically accept MO2 Quick Install dialogs",
+                True,
+            ),
+            mobase.PluginSetting(
+                "auto_dismiss_known_post_install_errors",
+                "Automatically dismiss known MO2 post-install error dialogs",
+                True,
+            ),
+            mobase.PluginSetting(
+                "auto_accept_fomod_defaults",
+                "Automatically accept default selections in MO2 installer dialogs",
+                True,
+            ),
+            mobase.PluginSetting(
+                "auto_merge_existing_mods",
+                "Automatically merge when MO2 reports that a mod already exists",
+                True,
+            ),
+            mobase.PluginSetting(
+                "activate_mods_after_install",
+                "Activate installed mods after the collection install pass completes",
+                False,
+            ),
+        ]
 
     def onUserInterfaceInitializedCallback(self, main_window: "QMainWindow"):
         self._stepSelectCollection = stepSelectCollection(main_window)

--- a/api.py
+++ b/api.py
@@ -1,8 +1,9 @@
 import json
 import urllib.request
-from PyQt6.QtCore import qDebug
 
 from . import var
+
+qDebug = var.debug
 
 
 def nxmFetch(requestData):

--- a/download.py
+++ b/download.py
@@ -1,4 +1,5 @@
 import re
+from pathlib import Path
 from PyQt6.QtCore import QObject, QSize, QThread, Qt, QUrl, pyqtSignal, qDebug
 from PyQt6.QtGui import QDesktopServices, QFontMetrics
 from PyQt6.QtWidgets import (
@@ -274,6 +275,24 @@ class stepModCount(QDialog):
         qDebug("[NXMColDL] stepModCount: Processing fetched mod data")
         qDebug(f"[NXMColDL] Mods Info: {var.cleanJson(mods)}")
         for mod in mods.get("collectionRevision", {}).get("modFiles", []):
+            mod_info = mod.get("file", {}).get("mod", {})
+            mod_domain = mod_info.get("game", {}).get("domainName")
+            if mod_domain and mod_domain != var.game:
+                mod_id = mod_info.get("modId")
+                var.externalMods.append(
+                    {
+                        "id": mod_id,
+                        "name": mod_info.get("name", "External Nexus resource"),
+                        "resourceType": f"Nexus {mod_domain}",
+                        "resourceUrl": f"https://www.nexusmods.com/{mod_domain}/mods/{mod_id}",
+                    }
+                )
+                qDebug(
+                    "[NXMColDL] Cross-domain mod added as external resource: "
+                    f"{mod_info.get('name')} ({mod_domain})"
+                )
+                continue
+
             if not mod.get("optional"):
                 var.essentialMods.append(mod)
                 qDebug(f"[NXMColDL] Essential mod added: {mod['file']['mod']['name']}")
@@ -675,6 +694,19 @@ class stepDownload(QDialog):
 
         plugin_instance = getattr(__meta__, "_download_plugin", None)
         if plugin_instance is not None:
+            try:
+                base_path = Path(plugin_instance._organizer.basePath())
+                metadata_file = var.saveCollectionMetadata(base_path)
+                qDebug(f"[NXMColDL] Collection metadata saved to: {metadata_file}")
+            except (ValueError, IOError) as e:
+                qDebug(f"[NXMColDL] Failed to save collection metadata: {e}")
+                QMessageBox.warning(
+                    self,
+                    "Warning",
+                    f"Failed to save collection metadata:\n\n{e}\n\n"
+                    "You will not be able to install this collection automatically later.",
+                )
+
             # Always open external resources if user chose to
             if var.chosenExternal and var.externalMods:
                 for mod in var.externalMods:
@@ -714,22 +746,6 @@ class stepDownload(QDialog):
                 )
                 progress_dialog.exec()
                 return
-
-            # Save collection metadata for later installation
-            try:
-                from pathlib import Path
-
-                base_path = Path(plugin_instance._organizer.basePath())
-                metadata_file = var.saveCollectionMetadata(base_path)
-                qDebug(f"[NXMColDL] Collection metadata saved to: {metadata_file}")
-            except (ValueError, IOError) as e:
-                qDebug(f"[NXMColDL] Failed to save collection metadata: {e}")
-                QMessageBox.warning(
-                    self,
-                    "Warning",
-                    f"Failed to save collection metadata:\n\n{e}\n\n"
-                    "You will not be able to install this collection automatically later.",
-                )
         else:
             qDebug(
                 "[NXMColDL] downloadMod called without active plugin instance; Aborting"

--- a/download.py
+++ b/download.py
@@ -1,6 +1,6 @@
 import re
 from pathlib import Path
-from PyQt6.QtCore import QObject, QSize, QThread, Qt, QUrl, pyqtSignal, qDebug
+from PyQt6.QtCore import QObject, QSize, QThread, QTimer, Qt, QUrl, pyqtSignal, qDebug
 from PyQt6.QtGui import QDesktopServices, QFontMetrics
 from PyQt6.QtWidgets import (
     QAbstractItemView,
@@ -691,6 +691,7 @@ class stepDownload(QDialog):
         self.mod_urls_to_open = []
         self.current_batch = 0
         self.batch_btn = None
+        self.progress_dialog = None
 
         plugin_instance = getattr(__meta__, "_download_plugin", None)
         if plugin_instance is not None:
@@ -731,6 +732,9 @@ class stepDownload(QDialog):
                 )
                 mods_to_download = var.essentialMods + var.chosenOptional
                 qDebug(f"[NXMColDL] Queueing {len(mods_to_download)} downloads")
+                self.progress_dialog = stepDownloadProgress(
+                    self.parent(), len(mods_to_download)
+                )
                 for mod in mods_to_download:
                     mod_id = mod["file"]["mod"]["modId"]
                     file_id = mod["file"]["fileId"]
@@ -740,12 +744,7 @@ class stepDownload(QDialog):
                     )
                     plugin_instance.downloadMod(mod)
 
-                self.close()
-                progress_dialog = stepDownloadProgress(
-                    self.parent(), len(mods_to_download)
-                )
-                progress_dialog.exec()
-                return
+                self.label.setText(f"Queued {len(mods_to_download)} downloads in MO2.")
         else:
             qDebug(
                 "[NXMColDL] downloadMod called without active plugin instance; Aborting"
@@ -766,6 +765,15 @@ class stepDownload(QDialog):
         self.submit_btn.clicked.connect(self.submit)
         self.layout.addWidget(self.submit_btn)
         self.setLayout(self.layout)
+
+        if self.progress_dialog is not None:
+            QTimer.singleShot(0, self.show_progress_dialog)
+
+    def show_progress_dialog(self):
+        """Run the progress dialog after this step's modal event loop starts."""
+        self.hide()
+        self.progress_dialog.exec()
+        self.accept()
 
     def update_batch_button(self):
         plugin_instance = getattr(__meta__, "_download_plugin", None)

--- a/download.py
+++ b/download.py
@@ -1,6 +1,6 @@
 import re
 from pathlib import Path
-from PyQt6.QtCore import QObject, QSize, QThread, QTimer, Qt, QUrl, pyqtSignal, qDebug
+from PyQt6.QtCore import QObject, QSize, QThread, QTimer, Qt, QUrl, pyqtSignal
 from PyQt6.QtGui import QDesktopServices, QFontMetrics
 from PyQt6.QtWidgets import (
     QAbstractItemView,
@@ -22,6 +22,8 @@ from PyQt6.QtWidgets import (
 from .api import fetchRevisions, fetchInfo, fetchModInfo
 from . import __meta__
 from . import var
+
+qDebug = var.debug
 
 
 class ModInfoWorker(QObject):

--- a/install.py
+++ b/install.py
@@ -2,7 +2,7 @@ import json
 from datetime import datetime
 from pathlib import Path
 
-from PyQt6.QtCore import Qt, QTimer, qDebug
+from PyQt6.QtCore import Qt, QTimer
 from PyQt6.QtWidgets import (
     QApplication,
     QDialogButtonBox,
@@ -19,6 +19,8 @@ from PyQt6.QtWidgets import (
 )
 
 from . import __meta__, var
+
+qDebug = var.debug
 
 MO2_WARNING_PATTERNS = (
     "Plugin not found:",

--- a/install.py
+++ b/install.py
@@ -26,6 +26,11 @@ MO2_WARNING_PATTERNS = (
     "[fomodinstallerdialog.cpp:",
 )
 
+EXPECTED_INSTALL_EXCEPTION_PATTERNS = (
+    "invalid origin name:",
+    "Plugin not found:",
+)
+
 
 def clickButtonByText(widget, texts):
     wanted = {text.lower() for text in texts}
@@ -411,6 +416,18 @@ class stepInstallMods(QDialog):
         qDebug(f"[NXMColDL Install] {message}")
         QApplication.processEvents()
 
+    def logInstallIssue(self, message, expected=False):
+        """Log install issues without making expected MO2 chatter look fatal."""
+        prefix = "NOTE" if expected else "ERROR"
+        level = "warning" if expected else "error"
+        self.log(f"  {prefix}: {message}", level)
+
+    def isExpectedInstallException(self, error):
+        message = str(error)
+        return any(
+            pattern in message for pattern in EXPECTED_INSTALL_EXCEPTION_PATTERNS
+        )
+
     def interfaceLogPath(self, organizer):
         return Path(organizer.downloadsPath()).parent / "logs" / "mo_interface.log"
 
@@ -533,7 +550,7 @@ class stepInstallMods(QDialog):
 
                 # Find downloaded file
                 if install_key not in download_map:
-                    self.log("  ERROR: Not found in downloads - skipping", "error")
+                    self.logInstallIssue("Not found in downloads - skipping")
                     self.log("")
                     continue
 
@@ -588,8 +605,8 @@ class stepInstallMods(QDialog):
                         if activate_after_install:
                             mods_to_activate.append(internal_name)
                     else:
-                        self.log(
-                            "  ERROR: Installation failed or was cancelled", "error"
+                        self.logInstallIssue(
+                            "Installation failed or was cancelled", expected=True
                         )
                 except Exception as e:
                     warning_count = self.collectInterfaceLogWarnings(
@@ -600,7 +617,10 @@ class stepInstallMods(QDialog):
                             f"  Captured {warning_count} MO2 warning(s) for report",
                             "warning",
                         )
-                    self.log(f"  ERROR: Installation error: {e}", "error")
+                    self.logInstallIssue(
+                        f"Installation issue: {e}",
+                        expected=self.isExpectedInstallException(e),
+                    )
 
                 self.log("")
 
@@ -612,10 +632,7 @@ class stepInstallMods(QDialog):
                     try:
                         modlist.setActive(internal_name, True)
                     except Exception as e:
-                        self.log(
-                            f"  ERROR: Could not activate {internal_name}: {e}",
-                            "error",
-                        )
+                        self.logInstallIssue(f"Could not activate {internal_name}: {e}")
                 warning_count = self.collectInterfaceLogWarnings(
                     log_path, log_offset, "post-install activation", ""
                 )

--- a/install.py
+++ b/install.py
@@ -256,19 +256,22 @@ class stepSelectCollection(QDialog):
             self.close()
             return
 
-        # Populate dropdown
+        # Populate dropdown with enough detail to distinguish concurrent
+        # collection downloads for the same game.
         for game, collection_id, revision, metadata_file in self.collections_list:
-            # Load metadata to get the display name
             try:
                 with open(metadata_file, "r", encoding="utf-8") as f:
                     metadata = json.load(f)
                     name = metadata.get("name", collection_id)
-                    # author = metadata.get("author", "Unknown")
-                    display_text = f"{name} (Rev {revision}) - {game}"
+                    total_mods = metadata.get("totalMods", "?")
+                    display_text = (
+                        f"{name} [{collection_id} rev {revision}, "
+                        f"{total_mods} mods] - {game}"
+                    )
                     self.dropdown.addItem(display_text)
             except Exception as e:
                 qDebug(f"[NXMColDL] Error loading metadata from {metadata_file}: {e}")
-                self.dropdown.addItem(f"{collection_id} (Rev {revision}) - {game}")
+                self.dropdown.addItem(f"{collection_id} [rev {revision}] - {game}")
 
         # Trigger initial selection
         if self.dropdown.count() > 0:
@@ -310,6 +313,8 @@ class stepSelectCollection(QDialog):
 				<br>
 				<br>
 				<b>Total Mods:</b> {total_mods}
+				<br>
+				<b>Collection:</b> {collection_id} rev {revision}
 				<br>
 				<b>Downloaded:</b> {timestamp.split("T")[0] if "T" in timestamp else timestamp}
 			""")

--- a/install.py
+++ b/install.py
@@ -1,9 +1,11 @@
 import json
+from datetime import datetime
 from pathlib import Path
 
 from PyQt6.QtCore import Qt, QTimer, qDebug
 from PyQt6.QtWidgets import (
     QApplication,
+    QDialogButtonBox,
     QComboBox,
     QDialog,
     QHBoxLayout,
@@ -17,6 +19,147 @@ from PyQt6.QtWidgets import (
 )
 
 from . import __meta__, var
+
+MO2_WARNING_PATTERNS = (
+    "Plugin not found:",
+    "invalid origin name:",
+    "[fomodinstallerdialog.cpp:",
+)
+
+
+def clickButtonByText(widget, texts):
+    wanted = {text.lower() for text in texts}
+    for button in widget.findChildren(QPushButton):
+        label = button.text().replace("&", "").strip().lower()
+        if label in wanted and button.isEnabled():
+            suppressDialogAndClick(widget, button)
+            return True
+    return False
+
+
+def suppressDialogAndClick(widget, button):
+    widget.setUpdatesEnabled(False)
+    widget.hide()
+    QApplication.processEvents()
+    button.click()
+
+
+def acceptQuickInstallDialog():
+    for widget in QApplication.topLevelWidgets():
+        if not widget.isVisible() or widget.windowTitle() != "Quick Install":
+            continue
+
+        for button_box in widget.findChildren(QDialogButtonBox):
+            button = button_box.button(QDialogButtonBox.StandardButton.Ok)
+            if button and button.isEnabled():
+                qDebug("[NXMColDL Install] Auto-accepting Quick Install dialog")
+                suppressDialogAndClick(widget, button)
+                return
+
+        for button in widget.findChildren(QPushButton):
+            if button.text().replace("&", "").lower() == "ok" and button.isEnabled():
+                qDebug("[NXMColDL Install] Auto-accepting Quick Install dialog")
+                suppressDialogAndClick(widget, button)
+                return
+
+
+def dismissKnownPostInstallErrorDialog(remaining=20):
+    if remaining <= 0:
+        return
+
+    for widget in QApplication.topLevelWidgets():
+        if not widget.isVisible() or widget.windowTitle() != "Error":
+            continue
+
+        labels = widget.findChildren(QLabel)
+        if not any(
+            "invalid origin name:" in label.text()
+            or "Plugin not found:" in label.text()
+            for label in labels
+        ):
+            continue
+
+        for button_box in widget.findChildren(QDialogButtonBox):
+            button = button_box.button(QDialogButtonBox.StandardButton.Ok)
+            if button and button.isEnabled():
+                qDebug("[NXMColDL Install] Dismissing known post-install error dialog")
+                suppressDialogAndClick(widget, button)
+                return
+
+        for button in widget.findChildren(QPushButton):
+            if button.text().replace("&", "").lower() == "ok" and button.isEnabled():
+                qDebug("[NXMColDL Install] Dismissing known post-install error dialog")
+                suppressDialogAndClick(widget, button)
+                return
+
+    QTimer.singleShot(250, lambda: dismissKnownPostInstallErrorDialog(remaining - 1))
+
+
+def acceptModExistsDialog():
+    for widget in QApplication.topLevelWidgets():
+        if not widget.isVisible() or widget.windowTitle() != "Mod Exists":
+            continue
+
+        if clickButtonByText(widget, ("Merge",)):
+            qDebug("[NXMColDL Install] Auto-merging Mod Exists dialog")
+            return
+
+
+def acceptDefaultInstallerDialog(remaining=80):
+    if remaining <= 0:
+        return
+
+    for widget in QApplication.topLevelWidgets():
+        if not widget.isVisible():
+            continue
+
+        title = widget.windowTitle()
+        if title in ("Error", "Quick Install") or title.startswith(
+            "NXM Collection Installer"
+        ):
+            continue
+
+        buttons = widget.findChildren(QPushButton)
+        button_by_text = {
+            button.text().replace("&", "").strip().lower(): button for button in buttons
+        }
+
+        # MO2 installer/FOMOD dialogs expose Next/Install buttons. Accept the
+        # already selected defaults, but do not click unrelated ordinary dialogs.
+        next_button = button_by_text.get("next")
+        install_button = button_by_text.get("install")
+        if next_button and next_button.isEnabled():
+            qDebug(f"[NXMColDL Install] Auto-accepting default installer page: {title}")
+            suppressDialogAndClick(widget, next_button)
+            QTimer.singleShot(300, lambda: acceptDefaultInstallerDialog(remaining - 1))
+            return
+
+        if install_button and install_button.isEnabled():
+            qDebug(
+                f"[NXMColDL Install] Auto-accepting default installer install: {title}"
+            )
+            suppressDialogAndClick(widget, install_button)
+            QTimer.singleShot(300, lambda: acceptDefaultInstallerDialog(remaining - 1))
+            return
+
+    QTimer.singleShot(300, lambda: acceptDefaultInstallerDialog(remaining - 1))
+
+
+def scheduleInstallDialogHandlers(
+    auto_accept_quick_install=True,
+    auto_dismiss_known_post_install_errors=True,
+    auto_accept_fomod_defaults=False,
+    auto_merge_existing_mods=True,
+):
+    for delay in (250, 750, 1500, 3000, 5000):
+        if auto_accept_quick_install:
+            QTimer.singleShot(delay, acceptQuickInstallDialog)
+        if auto_dismiss_known_post_install_errors:
+            QTimer.singleShot(delay, dismissKnownPostInstallErrorDialog)
+        if auto_merge_existing_mods:
+            QTimer.singleShot(delay, acceptModExistsDialog)
+    if auto_accept_fomod_defaults:
+        QTimer.singleShot(250, acceptDefaultInstallerDialog)
 
 
 class stepSelectCollection(QDialog):
@@ -250,6 +393,7 @@ class stepInstallMods(QDialog):
         layout.addWidget(self.close_btn)
 
         self.setLayout(layout)
+        self.install_warnings = []
 
         # Start installation after dialog is shown
         QTimer.singleShot(100, self.startInstallation)
@@ -266,6 +410,57 @@ class stepInstallMods(QDialog):
         self.log_text.append(f'<span style="color: {color};">{message}</span>')
         qDebug(f"[NXMColDL Install] {message}")
         QApplication.processEvents()
+
+    def interfaceLogPath(self, organizer):
+        return Path(organizer.downloadsPath()).parent / "logs" / "mo_interface.log"
+
+    def captureInterfaceLogPosition(self, organizer):
+        log_path = self.interfaceLogPath(organizer)
+        try:
+            return log_path, log_path.stat().st_size
+        except OSError:
+            return log_path, 0
+
+    def collectInterfaceLogWarnings(self, log_path, offset, mod_name, file_name):
+        captured = 0
+        try:
+            with open(log_path, "r", encoding="utf-8", errors="replace") as log_file:
+                log_file.seek(offset)
+                for line in log_file:
+                    line = line.rstrip()
+                    if not any(pattern in line for pattern in MO2_WARNING_PATTERNS):
+                        continue
+                    warning = {
+                        "mod": mod_name,
+                        "file": file_name,
+                        "message": line,
+                    }
+                    self.install_warnings.append(warning)
+                    captured += 1
+        except OSError as e:
+            qDebug(f"[NXMColDL Install] Could not read MO2 interface log: {e}")
+        return captured
+
+    def writeWarningReport(self, organizer):
+        if not self.install_warnings:
+            return None
+
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        report_path = (
+            self.interfaceLogPath(organizer).parent
+            / f"nxm-collection-install-warnings-{var.collection}-{var.revision}-{timestamp}.json"
+        )
+        report = {
+            "collection": var.collection,
+            "revision": var.revision,
+            "name": var.name,
+            "generated": datetime.now().isoformat(timespec="seconds"),
+            "warning_count": len(self.install_warnings),
+            "warnings": self.install_warnings,
+        }
+        with open(report_path, "w", encoding="utf-8") as report_file:
+            json.dump(report, report_file, indent=2)
+        return report_path
 
     def startInstallation(self):
         """Main installation process"""
@@ -301,10 +496,14 @@ class stepInstallMods(QDialog):
             # Build a mapping of (modId, fileId) -> download_path
             download_map = self.buildDownloadMap(downloads_path)
             self.log(f"Found {len(download_map)} downloaded files")
+
+            installed_map = self.buildInstalledMap(Path(organizer.modsPath()))
+            self.log(f"Found {len(installed_map)} installed Nexus file records")
             self.log("")
 
             # Install each mod in order
             installed_mods = []
+            mods_to_activate = []
             for idx, mod_info in enumerate(mods_to_install, 1):
                 self.progress_label.setText(
                     f"Installing mod {idx}/{len(mods_to_install)}"
@@ -319,42 +518,112 @@ class stepInstallMods(QDialog):
                 self.log(f"[{idx}/{len(mods_to_install)}] Processing: {mod_name}")
                 self.log(f"  File: {file_name} (ModID: {mod_id}, FileID: {file_id})")
 
+                install_key = (int(mod_id), int(file_id))
+                if install_key in installed_map:
+                    internal_name = installed_map[install_key]
+                    self.log(f"  Already installed as: {internal_name}", "success")
+                    self.log("")
+                    installed_mods.append(internal_name)
+                    activate_after_install = organizer.pluginSetting(
+                        plugin_instance.name(), "activate_mods_after_install"
+                    )
+                    if activate_after_install:
+                        mods_to_activate.append(internal_name)
+                    continue
+
                 # Find downloaded file
-                download_key = (int(mod_id), int(file_id))
-                if download_key not in download_map:
+                if install_key not in download_map:
                     self.log("  ERROR: Not found in downloads - skipping", "error")
                     self.log("")
                     continue
 
-                download_path = download_map[download_key]
+                download_path = download_map[install_key]
                 self.log(f"  Found: {download_path.name}")
 
                 # Install the mod
+                log_path, log_offset = self.captureInterfaceLogPosition(organizer)
                 try:
-                    installed_mod = organizer.installMod(str(download_path), mod_name)
+                    auto_accept_quick_install = organizer.pluginSetting(
+                        plugin_instance.name(), "auto_accept_quick_install"
+                    )
+                    auto_dismiss_known_post_install_errors = organizer.pluginSetting(
+                        plugin_instance.name(),
+                        "auto_dismiss_known_post_install_errors",
+                    )
+                    auto_accept_fomod_defaults = organizer.pluginSetting(
+                        plugin_instance.name(), "auto_accept_fomod_defaults"
+                    )
+                    auto_merge_existing_mods = organizer.pluginSetting(
+                        plugin_instance.name(), "auto_merge_existing_mods"
+                    )
+                    activate_after_install = organizer.pluginSetting(
+                        plugin_instance.name(), "activate_mods_after_install"
+                    )
+                    scheduleInstallDialogHandlers(
+                        auto_accept_quick_install,
+                        auto_dismiss_known_post_install_errors,
+                        auto_accept_fomod_defaults,
+                        auto_merge_existing_mods,
+                    )
+
+                    installed_mod = organizer.installMod(str(download_path))
+                    warning_count = self.collectInterfaceLogWarnings(
+                        log_path, log_offset, mod_name, file_name
+                    )
+                    if warning_count:
+                        self.log(
+                            f"  Captured {warning_count} MO2 warning(s) for report",
+                            "warning",
+                        )
                     if installed_mod:
                         internal_name = installed_mod.name()
-                        modlist.setActive(internal_name, True)
                         self.log(f"  Installed as: {internal_name}", "success")
 
-                        # Set priority to maintain collection order
-                        target_priority = base_priority + len(installed_mods)
-                        if modlist.setPriority(internal_name, target_priority):
-                            self.log(f"  Priority set to: {target_priority}", "success")
-                        else:
-                            self.log(
-                                f"  WARNING: Failed to set priority to {target_priority}",
-                                "warning",
-                            )
+                        self.log(
+                            "  Priority unchanged; MO2 appended the mod to the list",
+                            "warning",
+                        )
 
                         installed_mods.append(internal_name)
+                        if activate_after_install:
+                            mods_to_activate.append(internal_name)
                     else:
                         self.log(
                             "  ERROR: Installation failed or was cancelled", "error"
                         )
                 except Exception as e:
+                    warning_count = self.collectInterfaceLogWarnings(
+                        log_path, log_offset, mod_name, file_name
+                    )
+                    if warning_count:
+                        self.log(
+                            f"  Captured {warning_count} MO2 warning(s) for report",
+                            "warning",
+                        )
                     self.log(f"  ERROR: Installation error: {e}", "error")
 
+                self.log("")
+
+            if mods_to_activate:
+                self.progress_label.setText("Activating installed mods...")
+                self.log(f"Activating {len(mods_to_activate)} installed mods...")
+                log_path, log_offset = self.captureInterfaceLogPosition(organizer)
+                for internal_name in mods_to_activate:
+                    try:
+                        modlist.setActive(internal_name, True)
+                    except Exception as e:
+                        self.log(
+                            f"  ERROR: Could not activate {internal_name}: {e}",
+                            "error",
+                        )
+                warning_count = self.collectInterfaceLogWarnings(
+                    log_path, log_offset, "post-install activation", ""
+                )
+                if warning_count:
+                    self.log(
+                        f"  Captured {warning_count} MO2 warning(s) during activation",
+                        "warning",
+                    )
                 self.log("")
 
             # Final summary
@@ -365,6 +634,10 @@ class stepInstallMods(QDialog):
             self.log(f"  Total mods: {len(mods_to_install)}")
             self.log(f"  Successfully installed: {len(installed_mods)}")
             self.log(f"  Failed/Skipped: {len(mods_to_install) - len(installed_mods)}")
+            self.log(f"  MO2 warnings captured: {len(self.install_warnings)}")
+            report_path = self.writeWarningReport(organizer)
+            if report_path:
+                self.log(f"  Warning report: {report_path}", "warning")
             qDebug(
                 f"[NXMColDL] Installation complete: {len(installed_mods)}/{len(mods_to_install)} succeeded"
             )
@@ -399,6 +672,14 @@ class stepInstallMods(QDialog):
                 # Only consider files that exist and are not directories
                 if not download_file.exists() or download_file.is_dir():
                     continue
+                if download_file.name.endswith(".unfinished"):
+                    qDebug(
+                        f"[NXMColDL] Skipping unfinished download: {download_file.name}"
+                    )
+                    continue
+                if download_file.stat().st_size == 0:
+                    qDebug(f"[NXMColDL] Skipping empty download: {download_file.name}")
+                    continue
 
                 # Parse the .meta file (it's an INI-style file)
                 mod_id = None
@@ -429,3 +710,33 @@ class stepInstallMods(QDialog):
                 qDebug(f"[NXMColDL] Unexpected error parsing {meta_file.name}: {e}")
 
         return download_map
+
+    def buildInstalledMap(self, mods_path: Path):
+        installed_map = {}
+
+        if not mods_path.exists():
+            qDebug(f"[NXMColDL] Mods path not found: {mods_path}")
+            return installed_map
+
+        for meta_file in mods_path.glob("*/meta.ini"):
+            mod_id = None
+            file_ids = []
+            try:
+                with open(meta_file, "r", encoding="utf-8", errors="replace") as f:
+                    for line in f:
+                        line = line.strip()
+                        if line.startswith("modid="):
+                            mod_id = int(line.split("=", 1)[1])
+                        elif "\\fileid=" in line:
+                            file_ids.append(int(line.split("=", 1)[1]))
+
+                if mod_id is None:
+                    continue
+
+                for file_id in file_ids:
+                    installed_map[(mod_id, file_id)] = meta_file.parent.name
+
+            except (ValueError, IOError) as e:
+                qDebug(f"[NXMColDL] Error parsing installed metadata {meta_file}: {e}")
+
+        return installed_map

--- a/var.py
+++ b/var.py
@@ -153,4 +153,13 @@ def listCollectionMetadata(base_path: Path):
                     )
                     continue
 
-    return collections
+    def metadata_sort_key(collection_info):
+        metadata_file = collection_info[3]
+        try:
+            with open(metadata_file, "r", encoding="utf-8") as f:
+                metadata = json.load(f)
+            return metadata.get("timestamp") or metadata_file.stat().st_mtime
+        except Exception:
+            return metadata_file.stat().st_mtime
+
+    return sorted(collections, key=metadata_sort_key, reverse=True)

--- a/var.py
+++ b/var.py
@@ -2,7 +2,7 @@ import json
 import re
 from pathlib import Path
 from datetime import datetime
-from PyQt6.QtCore import qDebug, QUrl
+from PyQt6.QtCore import QUrl, qDebug as _qDebug
 from PyQt6.QtGui import QPixmap
 from PyQt6.QtCore import Qt
 from PyQt6.QtNetwork import QNetworkAccessManager, QNetworkRequest, QNetworkReply
@@ -24,6 +24,15 @@ bundledMods = []
 chosenOptional = []
 chosenExternal = True
 openModWebsites = False
+
+
+def debug(message):
+    """Send text to MO2's debug log without crashing on non-ASCII Nexus data."""
+    safe_message = str(message).encode("ascii", "backslashreplace").decode("ascii")
+    _qDebug(safe_message)
+
+
+qDebug = debug
 
 
 def cleanJson(data, visible=False):


### PR DESCRIPTION
# Improve collection download and install flow

## Summary
- Save collection metadata before queueing downloads so automatic installation remains available after Premium download mode closes the download dialog.
- Treat cross-domain Nexus mod files as external resources instead of queueing them against the active game domain.
- Make collection installation resumable by detecting already downloaded and already installed files from MO2 metadata.
- Sort downloaded collection metadata newest-first and show collection slug, revision, and mod count in the install selector so multiple pending collections are distinguishable.
- Avoid leaving a blank direct-download step dialog after the MO2 download queue has been handed off to the progress dialog.
- Add opt-in automation around common MO2 collection-install interruptions: Quick Install, default installer/FOMOD pages, known post-install error dialogs, and existing-mod merge prompts.
- Defer mod activation until after the install pass, disabled by default, to avoid noisy dependency/plugin validation while a collection is only partially installed.
- Capture known MO2 warning lines into a timestamped JSON report for later review.
- Make debug logging ASCII-safe so non-ASCII Nexus collection names do not crash qDebug under Wine/Proton.

## Notes
- The automation only acts on explicitly matched MO2 dialogs and leaves collection install activation disabled by default.
- FOMOD/default-page automation can be disabled via plugin settings.
- Direct Nexus "Add Collection" link handling is intentionally out of scope for this PR.
- A more ambitious retry loop for MO2's "Another installation is currently in progress" modal state was tested and left out because MO2 2.5.2 can flicker/steal focus when driven that aggressively. A safer queued installer design should be handled separately.

## Verification
- `ruff check .`
- `ruff format --check .`
- `uv run python -m py_compile __meta__.py download.py install.py var.py api.py`
- `git diff --check`
- Manual Linux/MO2 test on CachyOS with MO2 2.5.2: Premium collection downloads queued successfully for a 559-download collection with no `.unfinished` or zero-byte files left behind; a 75-download collection also completed cleanly while coexisting with the earlier collection metadata; the selector clearly defaulted to the newest 75-mod collection (`8vdyr1` rev 12) instead of the older 559-mod collection (`xxsqm4` rev 99).
