### PR TITLE
Optionally advance FOMOD default choices

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ choices. Installed mods are not enabled by default; enable
 to check them in MO2 after it finishes. Collection files are installed as
 separate MO2 mod rows by default; repeated files from the same Nexus mod use
 `#2`, `#3`, and later suffixes instead of silently merging into one row. FOMOD
-choice replay is not implemented.
+choice replay is not implemented, but `auto_advance_fomod_defaults` can
+optionally advance visible FOMOD installers by accepting their selected default
+choices.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ A Mod Organizer 2 plugin that lets you download Nexus Mods collections directly 
    - If you don't have Premium, make sure to check the 'Open in Browser' option to open the mod pages in your web browser for manual downloading.
 6. Install the downloaded mods in MO2 using the 'Install Downloaded Collection' tool.
 
+The installer processes one downloaded archive at a time and waits briefly before
+starting the next archive. This avoids overlapping MO2 installer sessions while
+still allowing normal MO2 installer dialogs to appear when a mod needs manual
+choices. Installed mods are not enabled by default; enable
+`activate_mods_after_install` in the plugin settings if you want the install pass
+to check them in MO2 after it finishes. Collection files are installed as
+separate MO2 mod rows by default; repeated files from the same Nexus mod use
+`#2`, `#3`, and later suffixes instead of silently merging into one row. FOMOD
+choice replay is not implemented.
+
 ## Contributing
 
 Contributions welcome! Feel free to open issues or submit pull requests.

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 import mobase
 
-from .__meta__ import DownloadCollectionTool, InstallCollectionTool
+from .__meta__ import CollectionModPage, DownloadCollectionTool, InstallCollectionTool
 
 
 def createPlugins() -> list[mobase.IPlugin]:
-    return [DownloadCollectionTool(), InstallCollectionTool()]
+    return [DownloadCollectionTool(), InstallCollectionTool(), CollectionModPage()]

--- a/__meta__.py
+++ b/__meta__.py
@@ -159,13 +159,13 @@ class InstallCollectionTool(mobase.IPluginTool):
                 True,
             ),
             mobase.PluginSetting(
-                "auto_accept_fomod_defaults",
-                "Automatically accept default selections in MO2 installer dialogs",
+                "auto_merge_existing_mods",
+                "Automatically merge when MO2 reports that a mod already exists",
                 True,
             ),
             mobase.PluginSetting(
-                "auto_merge_existing_mods",
-                "Automatically merge when MO2 reports that a mod already exists",
+                "install_files_as_separate_mods",
+                "Install each collection file as a separate named MO2 mod",
                 True,
             ),
             mobase.PluginSetting(

--- a/__meta__.py
+++ b/__meta__.py
@@ -146,7 +146,34 @@ class InstallCollectionTool(mobase.IPluginTool):
         dlg.exec()
 
     def settings(self):
-        return [mobase.PluginSetting("enabled", "Enable", True)]
+        return [
+            mobase.PluginSetting("enabled", "Enable", True),
+            mobase.PluginSetting(
+                "auto_accept_quick_install",
+                "Automatically accept MO2 Quick Install dialogs",
+                True,
+            ),
+            mobase.PluginSetting(
+                "auto_dismiss_known_post_install_errors",
+                "Automatically dismiss known MO2 post-install error dialogs",
+                True,
+            ),
+            mobase.PluginSetting(
+                "auto_accept_fomod_defaults",
+                "Automatically accept default selections in MO2 installer dialogs",
+                True,
+            ),
+            mobase.PluginSetting(
+                "auto_merge_existing_mods",
+                "Automatically merge when MO2 reports that a mod already exists",
+                True,
+            ),
+            mobase.PluginSetting(
+                "activate_mods_after_install",
+                "Activate installed mods after the collection install pass completes",
+                False,
+            ),
+        ]
 
     def onUserInterfaceInitializedCallback(self, main_window: "QMainWindow"):
         self._stepSelectCollection = stepSelectCollection(main_window)

--- a/__meta__.py
+++ b/__meta__.py
@@ -1,16 +1,80 @@
 import mobase  # type: ignore
-from PyQt6.QtCore import qDebug
+from PyQt6.QtCore import QTimer, QUrl, qDebug
 from PyQt6.QtGui import QIcon
 from PyQt6.QtWidgets import QMainWindow
-from .download import stepURL
+from .collection_helpers import parseCollectionAddress
+from .download import stepCollectionLinkFlow, stepURL
 from .install import stepSelectCollection
 from pathlib import Path
 
 PLUGIN_VERSION = mobase.VersionInfo(1, 0, 0, mobase.ReleaseType.ALPHA)
+_active_collection_link_flow = None
 
 
 def icon(icon_name: str) -> QIcon:
     return QIcon(str(Path(__file__).parent / "icons" / icon_name))
+
+
+def pendingLinkFiles(organizer: mobase.IOrganizer):
+    """Return rendezvous paths for external nxm:// collection handlers.
+
+    The MO2 data directory is the preferred path. The plugin directory is a
+    fallback because it maps cleanly as both /home/... on Linux and Z:/home/...
+    inside Wine/Proton.
+    """
+    return [
+        Path(organizer.basePath()) / "collections" / "pending-nxm-link.txt",
+        Path(__file__).parent / "pending-nxm-link.txt",
+    ]
+
+
+def consumePendingCollectionLink(organizer: mobase.IOrganizer, parent):
+    global _active_collection_link_flow
+    if _active_collection_link_flow and _active_collection_link_flow.isVisible():
+        return
+
+    url = None
+    for pending_file in pendingLinkFiles(organizer):
+        try:
+            if not pending_file.exists():
+                continue
+            url = pending_file.read_text(encoding="utf-8").strip()
+            pending_file.unlink()
+            break
+        except OSError as e:
+            qDebug(f"[NXMColDL] Failed to consume pending collection link: {e}")
+            return
+
+    if not url:
+        return
+
+    if not parseCollectionAddress(url):
+        qDebug(f"[NXMColDL] Ignoring invalid pending collection link: {url}")
+        return
+
+    qDebug(f"[NXMColDL] Consuming pending collection link: {url}")
+    _active_collection_link_flow = stepCollectionLinkFlow(
+        url,
+        parent,
+        auto_install=organizer.pluginSetting(
+            "NXM Collection Link Handler", "auto_install_after_download"
+        ),
+    )
+    _active_collection_link_flow.exec()
+    _active_collection_link_flow = None
+
+
+def startPendingLinkWatcher(plugin):
+    if getattr(plugin, "_pending_link_timer", None):
+        return
+
+    plugin._pending_link_timer = QTimer()
+    plugin._pending_link_timer.timeout.connect(
+        lambda: consumePendingCollectionLink(plugin._organizer, plugin._parent)
+    )
+    plugin._pending_link_timer.start(1000)
+    paths = ", ".join(str(path) for path in pendingLinkFiles(plugin._organizer))
+    qDebug(f"[NXMColDL] Watching for collection links at {paths}")
 
 
 class DownloadCollectionTool(mobase.IPluginTool):
@@ -19,6 +83,8 @@ class DownloadCollectionTool(mobase.IPluginTool):
     def __init__(self):
         super().__init__()
         self._organizer = None
+        self._parent = None
+        self._pending_link_timer = None
 
     def init(self, organizer: mobase.IOrganizer):
         self._organizer = organizer
@@ -81,10 +147,27 @@ class DownloadCollectionTool(mobase.IPluginTool):
                 "Open external mod URLs in browser by default",
                 True,
             ),
+            mobase.PluginSetting(
+                "download_retry_count",
+                "Retry failed collection downloads this many times",
+                2,
+            ),
+            mobase.PluginSetting(
+                "download_success_close_delay_seconds",
+                "Close successful download progress dialogs after this many seconds (0 disables)",
+                5,
+            ),
+            mobase.PluginSetting(
+                "stale_unfinished_retry_seconds",
+                "Retry zero-byte unfinished downloads after this many idle seconds (0 disables)",
+                60,
+            ),
         ]
 
     def onUserInterfaceInitializedCallback(self, main_window: "QMainWindow"):
+        self._parent = main_window
         self._stepURL = stepURL(main_window)
+        startPendingLinkWatcher(self)
 
     def downloadMod(self, modInfo: dict):
         modID = int(modInfo["file"]["mod"]["modId"])
@@ -171,9 +254,100 @@ class InstallCollectionTool(mobase.IPluginTool):
             mobase.PluginSetting(
                 "activate_mods_after_install",
                 "Activate installed mods after the collection install pass completes",
-                False,
+                True,
             ),
         ]
 
     def onUserInterfaceInitializedCallback(self, main_window: "QMainWindow"):
         self._stepSelectCollection = stepSelectCollection(main_window)
+
+
+class CollectionModPage(mobase.IPluginModPage):
+    _organizer: mobase.IOrganizer
+
+    def __init__(self):
+        super().__init__()
+        self._organizer = None
+        self._parent = None
+
+    def init(self, organizer: mobase.IOrganizer):
+        self._organizer = organizer
+        qDebug("[NXMColDL] Initializing Nexus collection link handler")
+        self._organizer.onUserInterfaceInitialized(
+            self.onUserInterfaceInitializedCallback
+        )
+        return True
+
+    def name(self) -> str:
+        return "NXM Collection Link Handler"
+
+    def displayName(self):
+        return "Nexus Mods Collections"
+
+    def author(self) -> str:
+        return "Furglitch"
+
+    def description(self) -> str:
+        return "Handles Nexus Mods Add Collection links"
+
+    def version(self) -> mobase.VersionInfo:
+        return PLUGIN_VERSION
+
+    def isActive(self) -> bool:
+        return self._organizer.pluginSetting(self.name(), "enabled")
+
+    def icon(self):
+        return icon("download.ico")
+
+    def pageURL(self):
+        return QUrl("https://www.nexusmods.com")
+
+    def useIntegratedBrowser(self):
+        return False
+
+    def setParentWidget(self, widget):
+        self._parent = widget
+
+    def onUserInterfaceInitializedCallback(self, main_window: "QMainWindow"):
+        self._parent = main_window
+
+    def settings(self):
+        return [
+            mobase.PluginSetting("enabled", "Enable", True),
+            mobase.PluginSetting(
+                "auto_install_after_download",
+                "Automatically install a collection after Add Collection downloads finish",
+                False,
+            ),
+        ]
+
+    def handlesDownload(self, page_url, download_url, fileinfo):
+        url = next(
+            (
+                candidate
+                for candidate in (download_url.toString(), page_url.toString())
+                if parseCollectionAddress(candidate)
+            ),
+            None,
+        )
+        if not url:
+            return False
+
+        qDebug(f"[NXMColDL] Handling collection link from Nexus: {url}")
+        auto_install = self._organizer.pluginSetting(
+            self.name(), "auto_install_after_download"
+        )
+        QTimer.singleShot(0, lambda: self.startCollectionFlow(url, auto_install))
+        return True
+
+    def startCollectionFlow(self, url, auto_install):
+        global _active_collection_link_flow
+        if _active_collection_link_flow and _active_collection_link_flow.isVisible():
+            qDebug("[NXMColDL] Collection link ignored; another flow is already active")
+            return
+
+        _active_collection_link_flow = stepCollectionLinkFlow(
+            url, self._parent, auto_install=auto_install
+        )
+        _active_collection_link_flow.exec()
+        _active_collection_link_flow = None

--- a/__meta__.py
+++ b/__meta__.py
@@ -247,6 +247,11 @@ class InstallCollectionTool(mobase.IPluginTool):
                 True,
             ),
             mobase.PluginSetting(
+                "auto_advance_fomod_defaults",
+                "Automatically accept default FOMOD installer choices",
+                False,
+            ),
+            mobase.PluginSetting(
                 "install_files_as_separate_mods",
                 "Install each collection file as a separate named MO2 mod",
                 True,

--- a/api.py
+++ b/api.py
@@ -1,8 +1,9 @@
 import json
 import urllib.request
-from PyQt6.QtCore import qDebug
 
 from . import var
+
+qDebug = var.debug
 
 
 def nxmFetch(requestData):

--- a/collection_helpers.py
+++ b/collection_helpers.py
@@ -1,0 +1,116 @@
+import re
+from configparser import ConfigParser
+from pathlib import Path
+
+
+def parseCollectionAddress(address):
+    """Parse supported Nexus collection web and nxm:// addresses."""
+    normalized = address.strip()
+    normalized = normalized.replace("http://", "https://")
+    normalized = normalized.split("?", 1)[0].split("#", 1)[0]
+    for suffix in ["/mods", "/comments", "/changelog", "/bugs"]:
+        if normalized.endswith(suffix):
+            normalized = normalized[: -len(suffix)]
+
+    web_match = re.match(
+        r"^https:\/\/(?:www\.)?nexusmods\.com\/games\/([a-zA-Z0-9_\-]+)"
+        r"\/collections\/([a-zA-Z0-9_\-]+)"
+        r"(?:\/revisions\/([0-9]+))?\/?$",
+        normalized,
+    )
+    if web_match:
+        return {
+            "uri": (
+                "https://www.nexusmods.com/games/"
+                f"{web_match.group(1)}/collections/{web_match.group(2)}"
+            ),
+            "game": web_match.group(1),
+            "collection": web_match.group(2),
+            "revision": int(web_match.group(3)) if web_match.group(3) else None,
+        }
+
+    nxm_match = re.match(
+        r"^nxm:\/\/([a-zA-Z0-9_\-]+)\/collections\/([a-zA-Z0-9_\-]+)"
+        r"\/revisions\/([0-9]+)\/?$",
+        normalized,
+    )
+    if nxm_match:
+        return {
+            "uri": (
+                "https://www.nexusmods.com/games/"
+                f"{nxm_match.group(1)}/collections/{nxm_match.group(2)}"
+            ),
+            "game": nxm_match.group(1),
+            "collection": nxm_match.group(2),
+            "revision": int(nxm_match.group(3)),
+        }
+
+    return None
+
+
+def downloadedFileKeys(downloads_dir):
+    """Return Nexus (mod_id, file_id) pairs with a completed archive on disk."""
+    keys = set()
+    if not downloads_dir or not downloads_dir.exists():
+        return keys
+
+    for metadata_file in downloads_dir.glob("*.meta"):
+        if metadata_file.name.endswith(".unfinished.meta"):
+            continue
+
+        parser = ConfigParser()
+        try:
+            parser.read(metadata_file, encoding="utf-8")
+            general = parser["General"]
+            mod_id = int(general["modID"])
+            file_id = int(general["fileID"])
+        except (OSError, KeyError, ValueError):
+            continue
+
+        archive_file = metadata_file.with_suffix("")
+        if archive_file.exists() and archive_file.stat().st_size > 0:
+            keys.add((mod_id, file_id))
+
+    return keys
+
+
+def readDownloadMetaKey(metadata_file):
+    """Read a Nexus (mod_id, file_id) pair from an MO2 download metadata file."""
+    parser = ConfigParser()
+    try:
+        parser.read(metadata_file, encoding="utf-8")
+        general = parser["General"]
+        return (int(general["modID"]), int(general["fileID"]))
+    except (OSError, KeyError, ValueError):
+        return None
+
+
+def unfinishedDownloadEntries(downloads_dir):
+    """Return unfinished MO2 download files indexed by Nexus (mod_id, file_id)."""
+    entries = {}
+    if not downloads_dir or not downloads_dir.exists():
+        return entries
+
+    for metadata_file in downloads_dir.glob("*.unfinished.meta"):
+        key = readDownloadMetaKey(metadata_file)
+        if key is None:
+            continue
+
+        archive_file = Path(str(metadata_file)[: -len(".meta")])
+        try:
+            archive_size = archive_file.stat().st_size if archive_file.exists() else 0
+            metadata_mtime = metadata_file.stat().st_mtime
+            archive_mtime = archive_file.stat().st_mtime if archive_file.exists() else 0
+        except OSError:
+            continue
+
+        entries.setdefault(key, []).append(
+            {
+                "archive": archive_file,
+                "metadata": metadata_file,
+                "archive_size": archive_size,
+                "mtime": max(metadata_mtime, archive_mtime),
+            }
+        )
+
+    return entries

--- a/collection_helpers.py
+++ b/collection_helpers.py
@@ -2,6 +2,54 @@ import re
 from configparser import ConfigParser
 from pathlib import Path
 
+FOMOD_ADVANCE_EXCLUDED_TITLES = {
+    "",
+    "Error",
+    "Install Mods",
+    "Mod Exists",
+    "Quick Install",
+    "NXM Collection Installer - Installing Mods",
+    "NXM Collection Installer - Select Collection",
+}
+
+
+def normalizedButtonLabel(label):
+    return " ".join(
+        str(label)
+        .replace("&", "")
+        .replace("<", "")
+        .replace(">", "")
+        .strip()
+        .lower()
+        .split()
+    )
+
+
+def installerDefaultActionLabel(window_title, buttons):
+    """Return the FOMOD default action to click, or None when unsafe.
+
+    ``buttons`` is an iterable of ``(label, enabled)`` pairs. The helper is kept
+    GUI-free so the dialog classification can be unit-tested outside MO2.
+    """
+    if window_title in FOMOD_ADVANCE_EXCLUDED_TITLES:
+        return None
+
+    enabled_by_label = {}
+    labels = set()
+    for label, enabled in buttons:
+        normalized = normalizedButtonLabel(label)
+        labels.add(normalized)
+        enabled_by_label[normalized] = bool(enabled)
+
+    if "cancel" not in labels:
+        return None
+
+    for label in ("next", "install"):
+        if enabled_by_label.get(label):
+            return label
+
+    return None
+
 
 def parseCollectionAddress(address):
     """Parse supported Nexus collection web and nxm:// addresses."""

--- a/download.py
+++ b/download.py
@@ -1,4 +1,5 @@
 import re
+from pathlib import Path
 from PyQt6.QtCore import QObject, QSize, QThread, Qt, QUrl, pyqtSignal, qDebug
 from PyQt6.QtGui import QDesktopServices, QFontMetrics
 from PyQt6.QtWidgets import (
@@ -274,6 +275,24 @@ class stepModCount(QDialog):
         qDebug("[NXMColDL] stepModCount: Processing fetched mod data")
         qDebug(f"[NXMColDL] Mods Info: {var.cleanJson(mods)}")
         for mod in mods.get("collectionRevision", {}).get("modFiles", []):
+            mod_info = mod.get("file", {}).get("mod", {})
+            mod_domain = mod_info.get("game", {}).get("domainName")
+            if mod_domain and mod_domain != var.game:
+                mod_id = mod_info.get("modId")
+                var.externalMods.append(
+                    {
+                        "id": mod_id,
+                        "name": mod_info.get("name", "External Nexus resource"),
+                        "resourceType": f"Nexus {mod_domain}",
+                        "resourceUrl": f"https://www.nexusmods.com/{mod_domain}/mods/{mod_id}",
+                    }
+                )
+                qDebug(
+                    "[NXMColDL] Cross-domain mod added as external resource: "
+                    f"{mod_info.get('name')} ({mod_domain})"
+                )
+                continue
+
             if not mod.get("optional"):
                 var.essentialMods.append(mod)
                 qDebug(f"[NXMColDL] Essential mod added: {mod['file']['mod']['name']}")
@@ -675,6 +694,19 @@ class stepDownload(QDialog):
 
         plugin_instance = getattr(__meta__, "_download_plugin", None)
         if plugin_instance is not None:
+            try:
+                base_path = Path(plugin_instance._organizer.basePath())
+                metadata_file = var.saveCollectionMetadata(base_path)
+                qDebug(f"[NXMColDL] Collection metadata saved to: {metadata_file}")
+            except (ValueError, IOError) as e:
+                qDebug(f"[NXMColDL] Failed to save collection metadata: {e}")
+                QMessageBox.warning(
+                    self,
+                    "Warning",
+                    f"Failed to save collection metadata:\n\n{e}\n\n"
+                    "You will not be able to install this collection automatically later.",
+                )
+
             # Always open external resources if user chose to
             if var.chosenExternal and var.externalMods:
                 for mod in var.externalMods:
@@ -714,22 +746,6 @@ class stepDownload(QDialog):
                 )
                 progress_dialog.exec()
                 return
-
-            # Save collection metadata for later installation
-            try:
-                from pathlib import Path
-
-                base_path = Path(plugin_instance._organizer.basePath())
-                metadata_file = var.saveCollectionMetadata(base_path)
-                qDebug(f"[NXMColDL] Collection metadata saved to: {metadata_file}")
-            except (ValueError, IOError) as e:
-                qDebug(f"[NXMColDL] Failed to save collection metadata: {e}")
-                QMessageBox.warning(
-                    self,
-                    "Warning",
-                    f"Failed to save collection metadata:\n\n{e}\n\n"
-                    "You will not be able to install this collection automatically later.",
-                )
         else:
             qDebug(
                 "[NXMColDL] downloadMod called without active plugin instance; Aborting"

--- a/download.py
+++ b/download.py
@@ -1,6 +1,6 @@
 import re
 from pathlib import Path
-from PyQt6.QtCore import QObject, QSize, QThread, Qt, QUrl, pyqtSignal, qDebug
+from PyQt6.QtCore import QObject, QSize, QThread, QTimer, Qt, QUrl, pyqtSignal, qDebug
 from PyQt6.QtGui import QDesktopServices, QFontMetrics
 from PyQt6.QtWidgets import (
     QAbstractItemView,
@@ -691,6 +691,7 @@ class stepDownload(QDialog):
         self.mod_urls_to_open = []
         self.current_batch = 0
         self.batch_btn = None
+        self.progress_dialog = None
 
         plugin_instance = getattr(__meta__, "_download_plugin", None)
         if plugin_instance is not None:
@@ -731,6 +732,9 @@ class stepDownload(QDialog):
                 )
                 mods_to_download = var.essentialMods + var.chosenOptional
                 qDebug(f"[NXMColDL] Queueing {len(mods_to_download)} downloads")
+                self.progress_dialog = stepDownloadProgress(
+                    self.parent(), len(mods_to_download)
+                )
                 for mod in mods_to_download:
                     mod_id = mod["file"]["mod"]["modId"]
                     file_id = mod["file"]["fileId"]
@@ -740,12 +744,7 @@ class stepDownload(QDialog):
                     )
                     plugin_instance.downloadMod(mod)
 
-                self.close()
-                progress_dialog = stepDownloadProgress(
-                    self.parent(), len(mods_to_download)
-                )
-                progress_dialog.exec()
-                return
+                self.label.setText(f"Queued {len(mods_to_download)} downloads in MO2.")
         else:
             qDebug(
                 "[NXMColDL] downloadMod called without active plugin instance; Aborting"
@@ -766,6 +765,15 @@ class stepDownload(QDialog):
         self.submit_btn.clicked.connect(self.submit)
         self.layout.addWidget(self.submit_btn)
         self.setLayout(self.layout)
+
+        if self.progress_dialog is not None:
+            QTimer.singleShot(0, self.show_progress_dialog)
+
+    def show_progress_dialog(self):
+        """Run the progress dialog after this step's modal event loop starts."""
+        self.hide()
+        self.progress_dialog.exec()
+        self.accept()
 
     def update_batch_button(self):
         plugin_instance = getattr(__meta__, "_download_plugin", None)

--- a/download.py
+++ b/download.py
@@ -1,4 +1,4 @@
-import re
+import time
 from pathlib import Path
 from PyQt6.QtCore import QObject, QSize, QThread, QTimer, Qt, QUrl, pyqtSignal
 from PyQt6.QtGui import QDesktopServices, QFontMetrics
@@ -22,8 +22,109 @@ from PyQt6.QtWidgets import (
 from .api import fetchRevisions, fetchInfo, fetchModInfo
 from . import __meta__
 from . import var
+from .collection_helpers import (
+    downloadedFileKeys,
+    parseCollectionAddress,
+    unfinishedDownloadEntries,
+)
 
 qDebug = var.debug
+
+
+def downloadDirectory():
+    plugin_instance = getattr(__meta__, "_download_plugin", None)
+    organizer = getattr(plugin_instance, "_organizer", None)
+    if not organizer:
+        return None
+    return Path(organizer.basePath()) / "downloads"
+
+
+def selectLatestRevision():
+    revisions = fetchRevisions(var.uri)
+    revision_list = (
+        revisions.get("collection", {}).get("revisions", []) if revisions else []
+    )
+    revision_numbers = [
+        revision.get("revisionNumber")
+        for revision in revision_list
+        if revision.get("revisionNumber") is not None
+    ]
+    return max(revision_numbers) if revision_numbers else None
+
+
+def applyCollectionAddress(address):
+    parsed = parseCollectionAddress(address)
+    if not parsed:
+        return None
+    var.uri = parsed["uri"]
+    var.game = parsed["game"]
+    var.collection = parsed["collection"]
+    var.revision = parsed["revision"]
+    qDebug(
+        "[NXMColDL] Collection address parsed: "
+        f"{var.game}/{var.collection} rev {var.revision or 'latest'}"
+    )
+    return parsed
+
+
+def populateCollectionInfo():
+    collection_data = fetchInfo(var.uri)
+    qDebug(f"[NXMColDL] Collection Info: {var.cleanJson(collection_data)}")
+    if not collection_data:
+        return False
+
+    collection = collection_data["collection"]
+    var.author = collection["user"]["name"]
+    var.name = collection["name"]
+    var.summary = var.cleanJson(collection["summary"], True)
+    var.thumbnail = collection.get("tileImage", {}).get("thumbnailUrl")
+    qDebug(f"[NXMColDL] Collection Name: {var.name}")
+    qDebug(f"[NXMColDL] Collection Author: {var.author}")
+    qDebug(f"[NXMColDL] Collection Summary: {var.summary}")
+    qDebug(f"[NXMColDL] Collection Thumbnail: {var.thumbnail}")
+    return True
+
+
+def populateCollectionMods(mods):
+    var.essentialMods.clear()
+    var.optionalMods.clear()
+    var.chosenOptional.clear()
+    var.externalMods.clear()
+    var.bundledMods.clear()
+
+    for mod in mods.get("collectionRevision", {}).get("modFiles", []):
+        mod_info = mod.get("file", {}).get("mod", {})
+        mod_domain = mod_info.get("game", {}).get("domainName")
+        if mod_domain and mod_domain != var.game:
+            mod_id = mod_info.get("modId")
+            var.externalMods.append(
+                {
+                    "id": mod_id,
+                    "name": mod_info.get("name", "External Nexus resource"),
+                    "resourceType": f"Nexus {mod_domain}",
+                    "resourceUrl": f"https://www.nexusmods.com/{mod_domain}/mods/{mod_id}",
+                }
+            )
+            qDebug(
+                "[NXMColDL] Cross-domain mod added as external resource: "
+                f"{mod_info.get('name')} ({mod_domain})"
+            )
+            continue
+
+        if not mod.get("optional"):
+            var.essentialMods.append(mod)
+            qDebug(f"[NXMColDL] Essential mod added: {mod['file']['mod']['name']}")
+        else:
+            var.optionalMods.append(mod)
+            qDebug(f"[NXMColDL] Optional mod added: {mod['file']['mod']['name']}")
+
+    for mod in mods.get("collectionRevision", {}).get("externalResources", []):
+        if mod.get("resourceUrl"):
+            var.externalMods.append(mod)
+            qDebug(f"[NXMColDL] External resource added: {mod.get('name')}")
+        else:
+            var.bundledMods.append(mod)
+            qDebug(f"[NXMColDL] Bundled resource added: {mod.get('name')}")
 
 
 class ModInfoWorker(QObject):
@@ -72,17 +173,11 @@ class stepURL(QDialog):
 
     def get_url(self):
         input_url = self.url_input.text().strip()
-        input_url = input_url.replace("http://", "https://")
-        for suffix in ["/mods", "/comments", "/changelog", "/bugs"]:
-            if input_url.endswith(suffix):
-                input_url = input_url[: -len(suffix)]
         qDebug(f"[NXMColDL] URL entered: {input_url}")
-        var.uri = input_url
-        return self.check_valid(input_url)
+        return applyCollectionAddress(input_url)
 
     def check_valid(self, url):
-        regex = r"^https:\/\/www\.nexusmods\.com\/games\/([a-zA-Z0-9_\-]+)\/collections\/([a-zA-Z0-9_\-]+)\/?$"
-        valid = re.match(regex, url)
+        valid = parseCollectionAddress(url)
         if valid:
             qDebug("[NXMColDL] URL is valid")
         return valid
@@ -97,12 +192,11 @@ class stepURL(QDialog):
                 "The URL you entered is not a valid Nexus Collection URL.",
             )
             return
-        var.game = matched.group(1)
-        qDebug(f"[NXMColDL] Game: {var.game}")
-        var.collection = matched.group(2)
-        qDebug(f"[NXMColDL] Collection ID: {var.collection}")
         self.close()
-        stepVersion(self.parent()).exec()
+        if var.revision:
+            stepModCount(self.parent()).exec()
+        else:
+            stepVersion(self.parent()).exec()
 
 
 class stepVersion(QDialog):
@@ -116,20 +210,7 @@ class stepVersion(QDialog):
         layout = QVBoxLayout()
 
         qDebug("[NXMColDL] Fetching collection info...")
-        collectionData = fetchInfo(var.uri)
-
-        qDebug(f"[NXMColDL] Collection Info: {var.cleanJson(collectionData)}")
-        if collectionData:
-            var.author = collectionData["collection"]["user"]["name"]
-            var.name = collectionData["collection"]["name"]
-            var.summary = var.cleanJson(collectionData["collection"]["summary"], True)
-            var.thumbnail = (
-                collectionData["collection"].get("tileImage", {}).get("thumbnailUrl")
-            )
-            qDebug(f"[NXMColDL] Collection Name: {var.name}")
-            qDebug(f"[NXMColDL] Collection Author: {var.author}")
-            qDebug(f"[NXMColDL] Collection Summary: {var.summary}")
-            qDebug(f"[NXMColDL] Collection Thumbnail: {var.thumbnail}")
+        populateCollectionInfo()
 
         infoBox = QHBoxLayout()
 
@@ -246,12 +327,6 @@ class stepModCount(QDialog):
         self.getMods()
 
     def getMods(self):
-        var.essentialMods.clear()
-        var.optionalMods.clear()
-        var.chosenOptional.clear()
-        var.externalMods.clear()
-        var.bundledMods.clear()
-
         # background process for loading modlist
         self._thread = QThread(self)
         self._worker = ModInfoWorker(var.uri)
@@ -276,38 +351,7 @@ class stepModCount(QDialog):
     def _on_mods_fetched(self, mods):
         qDebug("[NXMColDL] stepModCount: Processing fetched mod data")
         qDebug(f"[NXMColDL] Mods Info: {var.cleanJson(mods)}")
-        for mod in mods.get("collectionRevision", {}).get("modFiles", []):
-            mod_info = mod.get("file", {}).get("mod", {})
-            mod_domain = mod_info.get("game", {}).get("domainName")
-            if mod_domain and mod_domain != var.game:
-                mod_id = mod_info.get("modId")
-                var.externalMods.append(
-                    {
-                        "id": mod_id,
-                        "name": mod_info.get("name", "External Nexus resource"),
-                        "resourceType": f"Nexus {mod_domain}",
-                        "resourceUrl": f"https://www.nexusmods.com/{mod_domain}/mods/{mod_id}",
-                    }
-                )
-                qDebug(
-                    "[NXMColDL] Cross-domain mod added as external resource: "
-                    f"{mod_info.get('name')} ({mod_domain})"
-                )
-                continue
-
-            if not mod.get("optional"):
-                var.essentialMods.append(mod)
-                qDebug(f"[NXMColDL] Essential mod added: {mod['file']['mod']['name']}")
-            else:
-                var.optionalMods.append(mod)
-                qDebug(f"[NXMColDL] Optional mod added: {mod['file']['mod']['name']}")
-        for mod in mods.get("collectionRevision", {}).get("externalResources", []):
-            if mod.get("resourceUrl"):
-                var.externalMods.append(mod)
-                qDebug(f"[NXMColDL] External resource added: {mod.get('name')}")
-            else:
-                var.bundledMods.append(mod)
-                qDebug(f"[NXMColDL] Bundled resource added: {mod.get('name')}")
+        populateCollectionMods(mods)
 
         essentialCount = len(var.essentialMods)
         optionalCount = len(var.optionalMods)
@@ -585,15 +629,46 @@ class stepSummary(QDialog):
 class stepDownloadProgress(QDialog):
     """Progress dialog that tracks download completion"""
 
-    def __init__(self, parent=None, total_mods=0):
+    def __init__(
+        self,
+        parent=None,
+        mods_to_download=None,
+        on_complete=None,
+        max_retries=2,
+        retry_delay_ms=2500,
+        stale_unfinished_seconds=60,
+        close_on_success=False,
+        success_close_delay_ms=0,
+    ):
         super().__init__(parent)
         self.setWindowTitle("NXM Collection Downloader - Download Progress")
         self.setMinimumWidth(350)
 
-        self.total_mods = total_mods
+        self.mods_to_download = mods_to_download or []
+        self.total_mods = len(self.mods_to_download)
+        self.on_complete = on_complete
+        self.max_retries = max(0, int(max_retries or 0))
+        self.retry_delay_ms = retry_delay_ms
+        self.stale_unfinished_seconds = max(0, int(stale_unfinished_seconds or 0))
+        self.close_on_success = close_on_success
+        self.success_close_delay_ms = max(0, int(success_close_delay_ms or 0))
         self.completed_count = 0
         self.failed_count = 0
+        self.retry_count = 0
         self.is_tracking = True
+        self.download_ids = {}
+        self.completed_keys = set()
+        self.failed_keys = set()
+        self.retry_attempts = {}
+        self.key_counts = {}
+        self.queued_keys = set()
+        self.reconcile_timer = QTimer(self)
+        self.reconcile_timer.setInterval(1000)
+        self.reconcile_timer.timeout.connect(self.reconcile_completed_downloads)
+        for mod in self.mods_to_download:
+            key = self.mod_key(mod)
+            self.key_counts[key] = self.key_counts.get(key, 0) + 1
+        self.already_downloaded_keys = downloadedFileKeys(downloadDirectory())
 
         layout = QVBoxLayout()
 
@@ -624,40 +699,270 @@ class stepDownloadProgress(QDialog):
             self.download_manager = plugin_instance._organizer.downloadManager()
             self.download_manager.onDownloadComplete(self.on_download_complete)
             self.download_manager.onDownloadFailed(self.on_download_failed)
+            self.download_manager.onDownloadPaused(self.on_download_paused)
             self.download_manager.onDownloadRemoved(self.on_download_removed)
+        else:
+            self.download_manager = None
+
+        QTimer.singleShot(0, self.queue_downloads)
+        self.reconcile_timer.start()
+
+    def mod_key(self, mod):
+        return (int(mod["file"]["mod"]["modId"]), int(mod["file"]["fileId"]))
+
+    def mod_label(self, mod):
+        return mod["file"]["mod"].get("name") or mod["file"].get("name") or "mod"
+
+    def queue_downloads(self):
+        plugin_instance = getattr(__meta__, "_download_plugin", None)
+        if not plugin_instance or not getattr(plugin_instance, "_organizer", None):
+            self.detail_label.setText(
+                "Failed to access Mod Organizer download manager."
+            )
+            self.detail_label.setStyleSheet("color: red;")
+            self.is_tracking = False
+            return
+
+        skipped = 0
+        for mod in self.mods_to_download:
+            key = self.mod_key(mod)
+            if key in self.completed_keys or key in self.queued_keys:
+                continue
+            if key in self.already_downloaded_keys:
+                self.completed_keys.add(key)
+                skipped += self.key_counts.get(key, 1)
+                continue
+            self.queued_keys.add(key)
+            self.queue_mod(mod)
+
+        if skipped:
+            self.completed_count = skipped
+            qDebug(
+                f"[NXMColDL Progress] Skipped {skipped} already-downloaded archive(s)"
+            )
+            self.update_progress()
+
+        if self.total_mods == 0:
+            self.finish_if_complete()
+        elif self.completed_count >= self.total_mods:
+            self.finish_if_complete()
+
+    def queue_mod(self, mod):
+        plugin_instance = getattr(__meta__, "_download_plugin", None)
+        key = self.mod_key(mod)
+        mod_id, file_id = key
+        mod_name = self.mod_label(mod)
+        qDebug(
+            "[NXMColDL] Queueing download - "
+            f"ModID: {mod_id}, FileID: {file_id}, Name: {mod_name}"
+        )
+        download_id = plugin_instance.downloadMod(mod)
+        self.download_ids[int(download_id)] = key
+        qDebug(
+            "[NXMColDL Progress] Tracking download "
+            f"ID {download_id} for ModID {mod_id}, FileID {file_id}"
+        )
+
+    def mod_by_key(self, key):
+        for mod in self.mods_to_download:
+            if self.mod_key(mod) == key:
+                return mod
+        return None
 
     def on_download_complete(self, download_id):
         """Called when a download completes successfully"""
         if not self.is_tracking:
             return
 
-        qDebug(f"[NXMColDL Progress] Download completed: ID {download_id}")
-        self.completed_count += 1
-        self.update_progress()
+        key = self.download_ids.pop(int(download_id), None)
+        if key is None or key in self.completed_keys:
+            return
 
-        if self.completed_count >= self.total_mods:
-            qDebug("[NXMColDL Progress] All downloads completed")
-            self.is_tracking = False
+        qDebug(f"[NXMColDL Progress] Download completed: ID {download_id}")
+        self.completed_keys.add(key)
+        self.completed_count += self.key_counts.get(key, 1)
+        self.update_progress()
+        self.finish_if_complete()
 
     def on_download_failed(self, download_id):
         """Called when a download fails"""
         if not self.is_tracking:
             return
 
-        qDebug(f"[NXMColDL Progress] Download failed: ID {download_id}")
-        self.failed_count += 1
-        self.completed_count += 1
-        self.update_progress()
+        key = self.download_ids.pop(int(download_id), None)
+        if key is None or key in self.completed_keys or key in self.failed_keys:
+            return
 
-        if self.completed_count >= self.total_mods:
-            qDebug(
-                f"[NXMColDL Progress] Download tracking complete. {self.failed_count} failed."
+        qDebug(f"[NXMColDL Progress] Download failed: ID {download_id}")
+        attempts = self.retry_attempts.get(key, 0)
+        if attempts < self.max_retries:
+            self.retry_attempts[key] = attempts + 1
+            self.retry_count += 1
+            self.queued_keys.discard(key)
+            mod = self.mod_by_key(key)
+            mod_name = self.mod_label(mod) if mod else f"ModID {key[0]}"
+            self.detail_label.setText(
+                f"Retrying {mod_name} ({attempts + 1}/{self.max_retries})..."
             )
-            self.is_tracking = False
+            self.detail_label.setStyleSheet("color: orange;")
+            qDebug(
+                "[NXMColDL Progress] Requeueing failed download "
+                f"ModID {key[0]}, FileID {key[1]} "
+                f"({attempts + 1}/{self.max_retries})"
+            )
+            if mod:
+                QTimer.singleShot(self.retry_delay_ms, lambda m=mod: self.queue_mod(m))
+            return
+
+        self.failed_keys.add(key)
+        self.failed_count += 1
+        self.completed_count += self.key_counts.get(key, 1)
+        self.update_progress()
+        self.finish_if_complete()
+
+    def on_download_paused(self, download_id):
+        if not self.is_tracking or int(download_id) not in self.download_ids:
+            return
+        qDebug(f"[NXMColDL Progress] Download paused: ID {download_id}")
+        self.detail_label.setText("A tracked download is paused in MO2.")
+        self.detail_label.setStyleSheet("color: orange;")
 
     def on_download_removed(self, download_id):
-        """Called when a download is removed/cancelled"""
-        pass
+        if not self.is_tracking:
+            return
+
+        key = self.download_ids.pop(int(download_id), None)
+        if key is None or key in self.completed_keys or key in self.failed_keys:
+            return
+
+        qDebug(f"[NXMColDL Progress] Download removed: ID {download_id}")
+        self.failed_keys.add(key)
+        self.failed_count += 1
+        self.completed_count += self.key_counts.get(key, 1)
+        self.update_progress()
+        self.finish_if_complete()
+
+    def reconcile_completed_downloads(self):
+        """Credit downloads that MO2 completed without emitting a tracked callback."""
+        if not self.is_tracking:
+            self.reconcile_timer.stop()
+            return
+
+        completed_on_disk = downloadedFileKeys(downloadDirectory())
+        newly_completed = (
+            completed_on_disk
+            & set(self.key_counts) - self.completed_keys - self.failed_keys
+        )
+        for key in newly_completed:
+            download_ids = [
+                download_id
+                for download_id, download_key in self.download_ids.items()
+                if download_key == key
+            ]
+            for download_id in download_ids:
+                self.download_ids.pop(download_id, None)
+
+            self.completed_keys.add(key)
+            self.completed_count += self.key_counts.get(key, 1)
+            qDebug(
+                "[NXMColDL Progress] Reconciled completed download from disk: "
+                f"ModID {key[0]}, FileID {key[1]}"
+            )
+
+        if newly_completed:
+            self.update_progress()
+            self.finish_if_complete()
+
+        if self.is_tracking:
+            self.retry_stale_unfinished_downloads()
+
+    def retry_stale_unfinished_downloads(self):
+        """Requeue zero-byte unfinished files that MO2 left idle without a callback."""
+        if not self.stale_unfinished_seconds:
+            return
+
+        downloads_dir = downloadDirectory()
+        pending_keys = set(self.key_counts) - self.completed_keys - self.failed_keys
+        entries_by_key = unfinishedDownloadEntries(downloads_dir)
+        now = time.time()
+
+        for key in pending_keys:
+            entries = entries_by_key.get(key)
+            if not entries:
+                continue
+            if any(entry["archive_size"] > 0 for entry in entries):
+                continue
+            newest_mtime = max(entry["mtime"] for entry in entries)
+            if now - newest_mtime < self.stale_unfinished_seconds:
+                continue
+
+            attempts = self.retry_attempts.get(key, 0)
+            if attempts >= self.max_retries:
+                self.failed_keys.add(key)
+                self.failed_count += 1
+                self.completed_count += self.key_counts.get(key, 1)
+                qDebug(
+                    "[NXMColDL Progress] Zero-byte unfinished download exhausted retries: "
+                    f"ModID {key[0]}, FileID {key[1]}"
+                )
+                continue
+
+            mod = self.mod_by_key(key)
+            if not mod:
+                continue
+
+            self.retry_attempts[key] = attempts + 1
+            self.retry_count += 1
+            self.queued_keys.discard(key)
+            download_ids = [
+                download_id
+                for download_id, download_key in self.download_ids.items()
+                if download_key == key
+            ]
+            for download_id in download_ids:
+                self.download_ids.pop(download_id, None)
+
+            for entry in entries:
+                for path_key in ("archive", "metadata"):
+                    try:
+                        entry[path_key].unlink(missing_ok=True)
+                    except OSError as exc:
+                        qDebug(
+                            "[NXMColDL Progress] Failed removing stale unfinished "
+                            f"{path_key} for ModID {key[0]}, FileID {key[1]}: {exc}"
+                        )
+
+            mod_name = self.mod_label(mod)
+            self.detail_label.setText(
+                f"Retrying stalled {mod_name} ({attempts + 1}/{self.max_retries})..."
+            )
+            self.detail_label.setStyleSheet("color: orange;")
+            qDebug(
+                "[NXMColDL Progress] Requeueing stale zero-byte unfinished download "
+                f"ModID {key[0]}, FileID {key[1]} "
+                f"({attempts + 1}/{self.max_retries})"
+            )
+            self.queued_keys.add(key)
+            QTimer.singleShot(self.retry_delay_ms, lambda m=mod: self.queue_mod(m))
+
+        self.update_progress()
+        self.finish_if_complete()
+
+    def finish_if_complete(self):
+        if self.completed_count < self.total_mods:
+            return
+
+        qDebug(
+            f"[NXMColDL Progress] Download tracking complete. {self.failed_count} failed."
+        )
+        self.is_tracking = False
+        self.reconcile_timer.stop()
+        if self.failed_count == 0 and self.on_complete:
+            if self.close_on_success:
+                self.accept()
+            QTimer.singleShot(0, self.on_complete)
+        elif self.failed_count == 0 and self.success_close_delay_ms:
+            QTimer.singleShot(self.success_close_delay_ms, self.accept)
 
     def update_progress(self):
         """Update the progress display"""
@@ -672,7 +977,12 @@ class stepDownloadProgress(QDialog):
             )
             self.detail_label.setStyleSheet("color: orange;")
         elif self.completed_count >= self.total_mods:
-            self.detail_label.setText("All downloads completed!")
+            if self.retry_count:
+                self.detail_label.setText(
+                    f"All downloads completed after {self.retry_count} retry attempt(s)!"
+                )
+            else:
+                self.detail_label.setText("All downloads completed!")
             self.detail_label.setStyleSheet("color: green;")
         else:
             self.detail_label.setText(
@@ -682,10 +992,11 @@ class stepDownloadProgress(QDialog):
 
 
 class stepDownload(QDialog):
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, on_complete=None):
         super().__init__(parent)
         self.setWindowTitle("NXM Collection Downloader - Downloading...")
         self.setMinimumWidth(150)
+        self.on_complete = on_complete
 
         self.layout = QVBoxLayout()
         self.label = QLabel("Preparing to download selected mods...")
@@ -734,17 +1045,32 @@ class stepDownload(QDialog):
                 )
                 mods_to_download = var.essentialMods + var.chosenOptional
                 qDebug(f"[NXMColDL] Queueing {len(mods_to_download)} downloads")
-                self.progress_dialog = stepDownloadProgress(
-                    self.parent(), len(mods_to_download)
-                )
-                for mod in mods_to_download:
-                    mod_id = mod["file"]["mod"]["modId"]
-                    file_id = mod["file"]["fileId"]
-                    mod_name = mod["file"]["mod"]["name"]
-                    qDebug(
-                        f"[NXMColDL] stepDownload: Queueing download - ModID: {mod_id}, FileID: {file_id}, Name: {mod_name}"
+                max_retries = int(
+                    plugin_instance._organizer.pluginSetting(
+                        plugin_instance.name(), "download_retry_count"
                     )
-                    plugin_instance.downloadMod(mod)
+                    or 0
+                )
+                success_close_delay_ms = 1000 * int(
+                    plugin_instance._organizer.pluginSetting(
+                        plugin_instance.name(), "download_success_close_delay_seconds"
+                    )
+                    or 0
+                )
+                stale_unfinished_seconds = int(
+                    plugin_instance._organizer.pluginSetting(
+                        plugin_instance.name(), "stale_unfinished_retry_seconds"
+                    )
+                    or 0
+                )
+                self.progress_dialog = stepDownloadProgress(
+                    self.parent(),
+                    mods_to_download,
+                    on_complete=self.on_complete,
+                    max_retries=max_retries,
+                    stale_unfinished_seconds=stale_unfinished_seconds,
+                    success_close_delay_ms=success_close_delay_ms,
+                )
 
                 self.label.setText(f"Queued {len(mods_to_download)} downloads in MO2.")
         else:
@@ -826,3 +1152,117 @@ class stepDownload(QDialog):
 
     def submit(self):
         self.close()
+
+
+class stepCollectionLinkFlow(QDialog):
+    """Fetch, download, and optionally install a collection from a direct link."""
+
+    def __init__(self, collection_url, parent=None, auto_install=True):
+        super().__init__(parent)
+        self.collection_url = collection_url
+        self.auto_install = auto_install
+        self.metadata = None
+        self.setWindowTitle("NXM Collection Downloader")
+        self.setMinimumWidth(420)
+
+        layout = QVBoxLayout()
+        self.label = QLabel("Preparing collection download...")
+        self.label.setWordWrap(True)
+        layout.addWidget(self.label)
+
+        self.setLayout(layout)
+        QTimer.singleShot(0, self.start)
+
+    def fail(self, message):
+        qDebug(f"[NXMColDL] Direct collection flow failed: {message}")
+        QMessageBox.critical(self, "Collection Download Failed", message)
+        self.reject()
+
+    def start(self):
+        if not applyCollectionAddress(self.collection_url):
+            self.fail("The Nexus collection link was not recognized.")
+            return
+
+        if not populateCollectionInfo():
+            self.fail("Failed to fetch collection information from Nexus Mods.")
+            return
+
+        if var.revision is None:
+            var.revision = selectLatestRevision()
+            if var.revision is None:
+                self.fail("Failed to determine the latest collection revision.")
+                return
+
+        self.label.setText(f"Fetching collection manifest for {var.name}...")
+        mods = fetchModInfo(var.uri)
+        if mods is None:
+            self.fail("Failed to fetch collection mod information from Nexus Mods.")
+            return
+
+        populateCollectionMods(mods)
+        var.chosenOptional = list(var.optionalMods)
+
+        plugin_instance = getattr(__meta__, "_download_plugin", None)
+        if not plugin_instance or not getattr(plugin_instance, "_organizer", None):
+            self.fail("Failed to access Mod Organizer.")
+            return
+
+        try:
+            base_path = Path(plugin_instance._organizer.basePath())
+            metadata_file = var.saveCollectionMetadata(base_path)
+            self.metadata = var.loadCollectionMetadata(
+                base_path, var.game, var.collection, var.revision
+            )
+            qDebug(f"[NXMColDL] Collection metadata saved to: {metadata_file}")
+        except (ValueError, IOError) as e:
+            self.fail(f"Failed to save collection metadata:\n\n{e}")
+            return
+
+        if var.chosenExternal and var.externalMods:
+            for mod in var.externalMods:
+                QDesktopServices.openUrl(QUrl(mod["resourceUrl"]))
+
+        if var.bundledMods:
+            qDebug(
+                "[NXMColDL] Direct collection flow found unsupported bundled "
+                f"resources: {len(var.bundledMods)}"
+            )
+
+        mods_to_download = var.essentialMods + var.chosenOptional
+        max_retries = int(
+            plugin_instance._organizer.pluginSetting(
+                plugin_instance.name(), "download_retry_count"
+            )
+            or 0
+        )
+        success_close_delay_ms = 1000 * int(
+            plugin_instance._organizer.pluginSetting(
+                plugin_instance.name(), "download_success_close_delay_seconds"
+            )
+            or 0
+        )
+        stale_unfinished_seconds = int(
+            plugin_instance._organizer.pluginSetting(
+                plugin_instance.name(), "stale_unfinished_retry_seconds"
+            )
+            or 0
+        )
+        self.progress_dialog = stepDownloadProgress(
+            self.parent(),
+            mods_to_download,
+            on_complete=self.install_after_download if self.auto_install else None,
+            max_retries=max_retries,
+            stale_unfinished_seconds=stale_unfinished_seconds,
+            close_on_success=self.auto_install,
+            success_close_delay_ms=success_close_delay_ms,
+        )
+        self.hide()
+        self.progress_dialog.exec()
+        self.accept()
+
+    def install_after_download(self):
+        if not self.metadata:
+            return
+        from .install import installCollectionMetadata
+
+        installCollectionMetadata(self.metadata, self.parent())

--- a/download.py
+++ b/download.py
@@ -1,6 +1,6 @@
 import re
 from pathlib import Path
-from PyQt6.QtCore import QObject, QSize, QThread, QTimer, Qt, QUrl, pyqtSignal, qDebug
+from PyQt6.QtCore import QObject, QSize, QThread, QTimer, Qt, QUrl, pyqtSignal
 from PyQt6.QtGui import QDesktopServices, QFontMetrics
 from PyQt6.QtWidgets import (
     QAbstractItemView,
@@ -22,6 +22,8 @@ from PyQt6.QtWidgets import (
 from .api import fetchRevisions, fetchInfo, fetchModInfo
 from . import __meta__
 from . import var
+
+qDebug = var.debug
 
 
 class ModInfoWorker(QObject):

--- a/install.py
+++ b/install.py
@@ -112,50 +112,9 @@ def acceptModExistsDialog():
             return
 
 
-def acceptDefaultInstallerDialog(remaining=80):
-    if remaining <= 0:
-        return
-
-    for widget in QApplication.topLevelWidgets():
-        if not widget.isVisible():
-            continue
-
-        title = widget.windowTitle()
-        if title in ("Error", "Quick Install") or title.startswith(
-            "NXM Collection Installer"
-        ):
-            continue
-
-        buttons = widget.findChildren(QPushButton)
-        button_by_text = {
-            button.text().replace("&", "").strip().lower(): button for button in buttons
-        }
-
-        # MO2 installer/FOMOD dialogs expose Next/Install buttons. Accept the
-        # already selected defaults, but do not click unrelated ordinary dialogs.
-        next_button = button_by_text.get("next")
-        install_button = button_by_text.get("install")
-        if next_button and next_button.isEnabled():
-            qDebug(f"[NXMColDL Install] Auto-accepting default installer page: {title}")
-            suppressDialogAndClick(widget, next_button)
-            QTimer.singleShot(300, lambda: acceptDefaultInstallerDialog(remaining - 1))
-            return
-
-        if install_button and install_button.isEnabled():
-            qDebug(
-                f"[NXMColDL Install] Auto-accepting default installer install: {title}"
-            )
-            suppressDialogAndClick(widget, install_button)
-            QTimer.singleShot(300, lambda: acceptDefaultInstallerDialog(remaining - 1))
-            return
-
-    QTimer.singleShot(300, lambda: acceptDefaultInstallerDialog(remaining - 1))
-
-
 def scheduleInstallDialogHandlers(
     auto_accept_quick_install=True,
     auto_dismiss_known_post_install_errors=True,
-    auto_accept_fomod_defaults=False,
     auto_merge_existing_mods=True,
 ):
     for delay in (250, 750, 1500, 3000, 5000):
@@ -165,8 +124,6 @@ def scheduleInstallDialogHandlers(
             QTimer.singleShot(delay, dismissKnownPostInstallErrorDialog)
         if auto_merge_existing_mods:
             QTimer.singleShot(delay, acceptModExistsDialog)
-    if auto_accept_fomod_defaults:
-        QTimer.singleShot(250, acceptDefaultInstallerDialog)
 
 
 class stepSelectCollection(QDialog):
@@ -398,17 +355,26 @@ class stepInstallMods(QDialog):
         self.log_text.setMinimumHeight(200)
         layout.addWidget(self.log_text)
 
+        button_row = QHBoxLayout()
+
+        self.cancel_btn = QPushButton("Cancel After Current")
+        self.cancel_btn.clicked.connect(self.cancelInstallation)
+        button_row.addWidget(self.cancel_btn)
+
         # Close button (initially disabled)
         self.close_btn = QPushButton("Close")
         self.close_btn.setEnabled(False)
         self.close_btn.clicked.connect(self.accept)
-        layout.addWidget(self.close_btn)
+        button_row.addWidget(self.close_btn)
+        layout.addLayout(button_row)
 
         self.setLayout(layout)
         self.install_warnings = []
+        self.install_context = None
+        self.cancel_requested = False
 
         # Start installation after dialog is shown
-        QTimer.singleShot(100, self.startInstallation)
+        QTimer.singleShot(500, self.startInstallation)
 
     def log(self, message, level="info"):
         color = "black"
@@ -434,6 +400,12 @@ class stepInstallMods(QDialog):
         return any(
             pattern in message for pattern in EXPECTED_INSTALL_EXCEPTION_PATTERNS
         )
+
+    def cancelInstallation(self):
+        self.cancel_requested = True
+        self.cancel_btn.setEnabled(False)
+        self.progress_label.setText("Cancelling after current install...")
+        self.log("Cancel requested; stopping after the current archive.", "warning")
 
     def interfaceLogPath(self, organizer):
         return Path(organizer.downloadsPath()).parent / "logs" / "mo_interface.log"
@@ -487,7 +459,7 @@ class stepInstallMods(QDialog):
         return report_path
 
     def startInstallation(self):
-        """Main installation process"""
+        """Prepare the install pass and queue the first archive."""
         qDebug(f"[NXMColDL] Starting installation: {var.name}")
         try:
             plugin_instance = getattr(__meta__, "_install_plugin", None)
@@ -525,158 +497,228 @@ class stepInstallMods(QDialog):
             self.log(f"Found {len(installed_map)} installed Nexus file records")
             self.log("")
 
-            # Install each mod in order
-            installed_mods = []
-            mods_to_activate = []
-            for idx, mod_info in enumerate(mods_to_install, 1):
-                self.progress_label.setText(
-                    f"Installing mod {idx}/{len(mods_to_install)}"
-                )
-                self.progress_bar.setValue(idx - 1)
-
-                mod_id = mod_info["file"]["mod"]["modId"]
-                file_id = mod_info["file"]["fileId"]
-                mod_name = mod_info["file"]["mod"]["name"]
-                file_name = mod_info["file"]["name"]
-
-                self.log(f"[{idx}/{len(mods_to_install)}] Processing: {mod_name}")
-                self.log(f"  File: {file_name} (ModID: {mod_id}, FileID: {file_id})")
-
-                install_key = (int(mod_id), int(file_id))
-                if install_key in installed_map:
-                    internal_name = installed_map[install_key]
-                    self.log(f"  Already installed as: {internal_name}", "success")
-                    self.log("")
-                    installed_mods.append(internal_name)
-                    activate_after_install = organizer.pluginSetting(
-                        plugin_instance.name(), "activate_mods_after_install"
-                    )
-                    if activate_after_install:
-                        mods_to_activate.append(internal_name)
-                    continue
-
-                # Find downloaded file
-                if install_key not in download_map:
-                    self.logInstallIssue("Not found in downloads - skipping")
-                    self.log("")
-                    continue
-
-                download_path = download_map[install_key]
-                self.log(f"  Found: {download_path.name}")
-
-                # Install the mod
-                log_path, log_offset = self.captureInterfaceLogPosition(organizer)
-                try:
-                    auto_accept_quick_install = organizer.pluginSetting(
-                        plugin_instance.name(), "auto_accept_quick_install"
-                    )
-                    auto_dismiss_known_post_install_errors = organizer.pluginSetting(
-                        plugin_instance.name(),
-                        "auto_dismiss_known_post_install_errors",
-                    )
-                    auto_accept_fomod_defaults = organizer.pluginSetting(
-                        plugin_instance.name(), "auto_accept_fomod_defaults"
-                    )
-                    auto_merge_existing_mods = organizer.pluginSetting(
-                        plugin_instance.name(), "auto_merge_existing_mods"
-                    )
-                    activate_after_install = organizer.pluginSetting(
-                        plugin_instance.name(), "activate_mods_after_install"
-                    )
-                    scheduleInstallDialogHandlers(
-                        auto_accept_quick_install,
-                        auto_dismiss_known_post_install_errors,
-                        auto_accept_fomod_defaults,
-                        auto_merge_existing_mods,
-                    )
-
-                    installed_mod = organizer.installMod(str(download_path))
-                    warning_count = self.collectInterfaceLogWarnings(
-                        log_path, log_offset, mod_name, file_name
-                    )
-                    if warning_count:
-                        self.log(
-                            f"  Captured {warning_count} MO2 warning(s) for report",
-                            "warning",
-                        )
-                    if installed_mod:
-                        internal_name = installed_mod.name()
-                        self.log(f"  Installed as: {internal_name}", "success")
-
-                        self.log(
-                            "  Priority unchanged; MO2 appended the mod to the list",
-                            "warning",
-                        )
-
-                        installed_mods.append(internal_name)
-                        if activate_after_install:
-                            mods_to_activate.append(internal_name)
-                    else:
-                        self.logInstallIssue(
-                            "Installation failed or was cancelled", expected=True
-                        )
-                except Exception as e:
-                    warning_count = self.collectInterfaceLogWarnings(
-                        log_path, log_offset, mod_name, file_name
-                    )
-                    if warning_count:
-                        self.log(
-                            f"  Captured {warning_count} MO2 warning(s) for report",
-                            "warning",
-                        )
-                    self.logInstallIssue(
-                        f"Installation issue: {e}",
-                        expected=self.isExpectedInstallException(e),
-                    )
-
-                self.log("")
-
-            if mods_to_activate:
-                self.progress_label.setText("Activating installed mods...")
-                self.log(f"Activating {len(mods_to_activate)} installed mods...")
-                log_path, log_offset = self.captureInterfaceLogPosition(organizer)
-                for internal_name in mods_to_activate:
-                    try:
-                        modlist.setActive(internal_name, True)
-                    except Exception as e:
-                        self.logInstallIssue(f"Could not activate {internal_name}: {e}")
-                warning_count = self.collectInterfaceLogWarnings(
-                    log_path, log_offset, "post-install activation", ""
-                )
-                if warning_count:
-                    self.log(
-                        f"  Captured {warning_count} MO2 warning(s) during activation",
-                        "warning",
-                    )
-                self.log("")
-
-            # Final summary
-            self.progress_bar.setValue(len(mods_to_install))
-            self.progress_label.setText("Installation complete!")
-            self.log("=" * 50)
-            self.log("Installation Summary:", "success")
-            self.log(f"  Total mods: {len(mods_to_install)}")
-            self.log(f"  Successfully installed: {len(installed_mods)}")
-            self.log(f"  Failed/Skipped: {len(mods_to_install) - len(installed_mods)}")
-            self.log(f"  MO2 warnings captured: {len(self.install_warnings)}")
-            report_path = self.writeWarningReport(organizer)
-            if report_path:
-                self.log(f"  Warning report: {report_path}", "warning")
-            qDebug(
-                f"[NXMColDL] Installation complete: {len(installed_mods)}/{len(mods_to_install)} succeeded"
-            )
-
-            if len(installed_mods) < len(mods_to_install):
-                self.log("", "warning")
-                self.log(
-                    "Some mods were not installed. Make sure all mods are downloaded first.",
-                    "warning",
-                )
+            self.install_context = {
+                "plugin_instance": plugin_instance,
+                "organizer": organizer,
+                "modlist": modlist,
+                "mods_to_install": mods_to_install,
+                "download_map": download_map,
+                "installed_map": installed_map,
+                "installed_mods": [],
+                "mods_to_activate": [],
+                "used_mod_names": set(modlist.allMods()),
+                "mod_name_counts": {},
+                "activation_enabled": organizer.pluginSetting(
+                    plugin_instance.name(), "activate_mods_after_install"
+                ),
+                "separate_file_installs": organizer.pluginSetting(
+                    plugin_instance.name(), "install_files_as_separate_mods"
+                ),
+                "next_index": 0,
+            }
+            QTimer.singleShot(1500, self.installNextMod)
 
         except Exception as e:
             self.log(f"Fatal error during installation: {e}", "error")
-        finally:
             self.close_btn.setEnabled(True)
+
+    def installNextMod(self):
+        if not self.install_context:
+            return
+
+        context = self.install_context
+        plugin_instance = context["plugin_instance"]
+        organizer = context["organizer"]
+        mods_to_install = context["mods_to_install"]
+        download_map = context["download_map"]
+        installed_map = context["installed_map"]
+        installed_mods = context["installed_mods"]
+        mods_to_activate = context["mods_to_activate"]
+        used_mod_names = context["used_mod_names"]
+        mod_name_counts = context["mod_name_counts"]
+
+        idx = context["next_index"] + 1
+        if self.cancel_requested:
+            self.finishInstallation(cancelled=True)
+            return
+
+        if idx > len(mods_to_install):
+            self.finishInstallation()
+            return
+
+        context["next_index"] = idx
+        self.progress_label.setText(f"Installing mod {idx}/{len(mods_to_install)}")
+        self.progress_bar.setValue(idx - 1)
+
+        mod_info = mods_to_install[idx - 1]
+        mod_id = mod_info["file"]["mod"]["modId"]
+        file_id = mod_info["file"]["fileId"]
+        mod_name = mod_info["file"]["mod"]["name"]
+        file_name = mod_info["file"]["name"]
+        install_key = (int(mod_id), int(file_id))
+
+        self.log(f"[{idx}/{len(mods_to_install)}] Processing: {mod_name}")
+        self.log(f"  File: {file_name} (ModID: {mod_id}, FileID: {file_id})")
+
+        activate_after_install = context["activation_enabled"]
+
+        if install_key in installed_map:
+            internal_name = installed_map[install_key]
+            self.log(f"  Already installed as: {internal_name}", "success")
+            self.log("")
+            installed_mods.append(internal_name)
+            if activate_after_install:
+                mods_to_activate.append(internal_name)
+            QTimer.singleShot(100, self.installNextMod)
+            return
+
+        if install_key not in download_map:
+            self.logInstallIssue("Not found in downloads - skipping")
+            self.log("")
+            QTimer.singleShot(100, self.installNextMod)
+            return
+
+        download_path = download_map[install_key]
+        self.log(f"  Found: {download_path.name}")
+
+        log_path, log_offset = self.captureInterfaceLogPosition(organizer)
+        try:
+            scheduleInstallDialogHandlers(
+                organizer.pluginSetting(
+                    plugin_instance.name(), "auto_accept_quick_install"
+                ),
+                organizer.pluginSetting(
+                    plugin_instance.name(),
+                    "auto_dismiss_known_post_install_errors",
+                ),
+                organizer.pluginSetting(
+                    plugin_instance.name(), "auto_merge_existing_mods"
+                ),
+            )
+
+            if context["separate_file_installs"]:
+                target_mod_name = self.allocateCollectionModName(
+                    mod_name, used_mod_names, mod_name_counts
+                )
+                self.log(f"  Target MO2 name: {target_mod_name}")
+                installed_mod = organizer.installMod(
+                    str(download_path), target_mod_name
+                )
+            else:
+                installed_mod = organizer.installMod(str(download_path))
+            warning_count = self.collectInterfaceLogWarnings(
+                log_path, log_offset, mod_name, file_name
+            )
+            if warning_count:
+                self.log(
+                    f"  Captured {warning_count} MO2 warning(s) for report",
+                    "warning",
+                )
+            if installed_mod:
+                internal_name = installed_mod.name()
+                self.log(f"  Installed as: {internal_name}", "success")
+                self.log(
+                    "  Priority unchanged; MO2 appended the mod to the list",
+                    "warning",
+                )
+                used_mod_names.add(internal_name)
+                installed_mods.append(internal_name)
+                installed_map[install_key] = internal_name
+                if activate_after_install:
+                    mods_to_activate.append(internal_name)
+            else:
+                self.logInstallIssue(
+                    "Installation failed or was cancelled", expected=True
+                )
+        except Exception as e:
+            warning_count = self.collectInterfaceLogWarnings(
+                log_path, log_offset, mod_name, file_name
+            )
+            if warning_count:
+                self.log(
+                    f"  Captured {warning_count} MO2 warning(s) for report",
+                    "warning",
+                )
+            self.logInstallIssue(
+                f"Installation issue: {e}",
+                expected=self.isExpectedInstallException(e),
+            )
+
+        self.log("")
+        QTimer.singleShot(1500, self.installNextMod)
+
+    def finishInstallation(self, cancelled=False):
+        if not self.install_context:
+            return
+
+        context = self.install_context
+        organizer = context["organizer"]
+        modlist = context["modlist"]
+        mods_to_install = context["mods_to_install"]
+        installed_mods = context["installed_mods"]
+        mods_to_activate = context["mods_to_activate"]
+        activation_enabled = context["activation_enabled"]
+        activated_count = 0
+
+        if mods_to_activate:
+            self.progress_label.setText("Activating installed mods...")
+            mods_to_activate = list(dict.fromkeys(mods_to_activate))
+            self.log(f"Activating {len(mods_to_activate)} installed mods...")
+            log_path, log_offset = self.captureInterfaceLogPosition(organizer)
+            for internal_name in mods_to_activate:
+                try:
+                    modlist.setActive(internal_name, True)
+                    activated_count += 1
+                except Exception as e:
+                    self.logInstallIssue(f"Could not activate {internal_name}: {e}")
+            warning_count = self.collectInterfaceLogWarnings(
+                log_path, log_offset, "post-install activation", ""
+            )
+            if warning_count:
+                self.log(
+                    f"  Captured {warning_count} MO2 warning(s) during activation",
+                    "warning",
+                )
+            self.log("")
+
+        self.progress_bar.setValue(len(mods_to_install))
+        if cancelled:
+            self.progress_label.setText("Installation cancelled.")
+        else:
+            self.progress_label.setText("Installation complete!")
+        self.log("=" * 50)
+        if cancelled:
+            self.log("Installation Summary (cancelled):", "warning")
+        else:
+            self.log("Installation Summary:", "success")
+        installed_containers = len(set(installed_mods))
+        self.log(f"  Collection file entries: {len(mods_to_install)}")
+        self.log(f"  Entries installed/already present: {len(installed_mods)}")
+        self.log(f"  MO2 mod containers touched: {installed_containers}")
+        if activation_enabled:
+            self.log(f"  Activated installed mods: {activated_count}")
+        else:
+            self.log("  Activated installed mods: 0 (activation disabled)")
+        self.log(
+            f"  Failed/skipped collection entries: {len(mods_to_install) - len(installed_mods)}"
+        )
+        self.log(f"  MO2 warnings captured: {len(self.install_warnings)}")
+        report_path = self.writeWarningReport(organizer)
+        if report_path:
+            self.log(f"  Warning report: {report_path}", "warning")
+        qDebug(
+            f"[NXMColDL] Installation complete: {len(installed_mods)}/{len(mods_to_install)} succeeded"
+        )
+
+        if len(installed_mods) < len(mods_to_install):
+            self.log("", "warning")
+            self.log(
+                "Some mods were not installed. Make sure all mods are downloaded first.",
+                "warning",
+            )
+
+        self.close_btn.setEnabled(True)
+        self.cancel_btn.setEnabled(False)
 
     def buildDownloadMap(self, downloads_path: Path):
         download_map = {}
@@ -734,6 +776,29 @@ class stepInstallMods(QDialog):
                 qDebug(f"[NXMColDL] Unexpected error parsing {meta_file.name}: {e}")
 
         return download_map
+
+    def allocateCollectionModName(self, mod_name, used_mod_names, mod_name_counts):
+        base_name = self.sanitizeModName(mod_name)
+        next_index = mod_name_counts.get(base_name, 1)
+
+        if next_index == 1 and base_name not in used_mod_names:
+            mod_name_counts[base_name] = 2
+            used_mod_names.add(base_name)
+            return base_name
+
+        next_index = max(next_index, 2)
+        while True:
+            candidate = f"{base_name} #{next_index}"
+            if candidate not in used_mod_names:
+                mod_name_counts[base_name] = next_index + 1
+                used_mod_names.add(candidate)
+                return candidate
+            next_index += 1
+
+    def sanitizeModName(self, mod_name):
+        clean_name = str(mod_name).replace("/", "-").replace("\\", "-")
+        clean_name = " ".join(clean_name.split())
+        return clean_name or "Collection Mod"
 
     def buildInstalledMap(self, mods_path: Path):
         installed_map = {}

--- a/install.py
+++ b/install.py
@@ -2,6 +2,7 @@ import json
 from datetime import datetime
 from pathlib import Path
 
+import mobase
 from PyQt6.QtCore import Qt, QTimer
 from PyQt6.QtWidgets import (
     QApplication,
@@ -618,8 +619,7 @@ class stepInstallMods(QDialog):
                 internal_name = installed_mod.name()
                 self.log(f"  Installed as: {internal_name}", "success")
                 self.log(
-                    "  Priority unchanged; MO2 appended the mod to the list",
-                    "warning",
+                    "  Priority will be checked after collection install",
                 )
                 used_mod_names.add(internal_name)
                 installed_mods.append(internal_name)
@@ -658,7 +658,15 @@ class stepInstallMods(QDialog):
         installed_mods = context["installed_mods"]
         mods_to_activate = context["mods_to_activate"]
         activation_enabled = context["activation_enabled"]
+        priority_order = None
         activated_count = 0
+        plugin_activation = None
+
+        if installed_mods:
+            priority_order = self.reconcileCollectionPriorityOrder(
+                modlist, installed_mods
+            )
+            self.log("")
 
         if mods_to_activate:
             self.progress_label.setText("Activating installed mods...")
@@ -679,6 +687,10 @@ class stepInstallMods(QDialog):
                     f"  Captured {warning_count} MO2 warning(s) during activation",
                     "warning",
                 )
+            if activation_enabled:
+                plugin_activation = self.activatePluginsForMods(
+                    organizer, mods_to_activate
+                )
             self.log("")
 
         self.progress_bar.setValue(len(mods_to_install))
@@ -695,8 +707,22 @@ class stepInstallMods(QDialog):
         self.log(f"  Collection file entries: {len(mods_to_install)}")
         self.log(f"  Entries installed/already present: {len(installed_mods)}")
         self.log(f"  MO2 mod containers touched: {installed_containers}")
+        if priority_order:
+            self.log(
+                "  Collection priority order: "
+                f"{priority_order['verified']} verified, "
+                f"{priority_order['moved']} moved, "
+                f"{priority_order['failed']} failed"
+            )
         if activation_enabled:
             self.log(f"  Activated installed mods: {activated_count}")
+            if plugin_activation:
+                self.log(
+                    "  Plugins from activated mods: "
+                    f"{plugin_activation['activated']} activated, "
+                    f"{plugin_activation['already_active']} already active, "
+                    f"{plugin_activation['blocked']} blocked"
+                )
         else:
             self.log("  Activated installed mods: 0 (activation disabled)")
         self.log(
@@ -719,6 +745,136 @@ class stepInstallMods(QDialog):
 
         self.close_btn.setEnabled(True)
         self.cancel_btn.setEnabled(False)
+
+    def reconcileCollectionPriorityOrder(self, modlist, installed_mods):
+        ordered_mods = list(dict.fromkeys(installed_mods))
+        result = {"verified": 0, "moved": 0, "failed": 0}
+        if len(ordered_mods) < 2:
+            result["verified"] = len(ordered_mods)
+            return result
+
+        priority_by_mod = {}
+        missing_mods = []
+        for mod_name in ordered_mods:
+            try:
+                priority_by_mod[mod_name] = modlist.priority(mod_name)
+            except Exception as e:
+                missing_mods.append(mod_name)
+                self.logInstallIssue(
+                    f"Could not read priority for {mod_name}: {e}",
+                    expected=True,
+                )
+
+        present_mods = [name for name in ordered_mods if name in priority_by_mod]
+        if not present_mods:
+            result["failed"] = len(missing_mods)
+            return result
+
+        current_priorities = [priority_by_mod[name] for name in present_mods]
+        if current_priorities == sorted(current_priorities):
+            result["verified"] = len(present_mods)
+            result["failed"] = len(missing_mods)
+            self.log(
+                f"Collection priority order verified for {len(present_mods)} mods",
+                "success",
+            )
+            return result
+
+        target_priority = min(current_priorities)
+        self.log(
+            "Collection priority order differed from the manifest; repairing...",
+            "warning",
+        )
+
+        # Moving each touched mod to the block start in reverse manifest order
+        # yields the requested ascending priority order while keeping the
+        # collection as one contiguous block.
+        for mod_name in reversed(present_mods):
+            try:
+                if modlist.setPriority(mod_name, target_priority):
+                    result["moved"] += 1
+                else:
+                    result["failed"] += 1
+                    self.logInstallIssue(
+                        f"Could not set priority for {mod_name}",
+                        expected=True,
+                    )
+            except Exception as e:
+                result["failed"] += 1
+                self.logInstallIssue(
+                    f"Could not set priority for {mod_name}: {e}",
+                    expected=True,
+                )
+
+        try:
+            repaired_priorities = [modlist.priority(name) for name in present_mods]
+        except Exception:
+            repaired_priorities = []
+        if repaired_priorities == sorted(repaired_priorities):
+            result["verified"] = len(present_mods)
+            self.log(
+                f"Collection priority order repaired for {len(present_mods)} mods",
+                "success",
+            )
+        else:
+            result["failed"] += len(present_mods)
+            self.logInstallIssue(
+                "Collection priority order still differs after repair",
+                expected=True,
+            )
+
+        result["failed"] += len(missing_mods)
+        return result
+
+    def activatePluginsForMods(self, organizer, mod_names):
+        plugin_list = organizer.pluginList()
+        mod_name_set = set(mod_names)
+        activated = 0
+        already_active = 0
+        blocked = 0
+
+        try:
+            organizer.refresh(True)
+        except Exception as e:
+            self.logInstallIssue(f"Could not refresh plugin list: {e}", expected=True)
+
+        self.log("Activating plugins from installed mods...")
+        for plugin_name in plugin_list.pluginNames():
+            try:
+                if plugin_list.origin(plugin_name) not in mod_name_set:
+                    continue
+
+                if plugin_list.state(plugin_name) == mobase.PluginState.ACTIVE:
+                    already_active += 1
+                    continue
+
+                plugin_list.setState(plugin_name, mobase.PluginState.ACTIVE)
+                if plugin_list.state(plugin_name) == mobase.PluginState.ACTIVE:
+                    activated += 1
+                else:
+                    blocked += 1
+                    masters = ", ".join(plugin_list.masters(plugin_name))
+                    detail = f"; masters: {masters}" if masters else ""
+                    self.log(
+                        f"  Plugin not activated by MO2: {plugin_name}{detail}",
+                        "warning",
+                    )
+            except Exception as e:
+                blocked += 1
+                self.logInstallIssue(
+                    f"Could not activate plugin {plugin_name}: {e}",
+                    expected=True,
+                )
+
+        self.log(
+            f"  Plugin activation: {activated} activated, "
+            f"{already_active} already active, {blocked} blocked"
+        )
+        return {
+            "activated": activated,
+            "already_active": already_active,
+            "blocked": blocked,
+        }
 
     def buildDownloadMap(self, downloads_path: Path):
         download_map = {}

--- a/install.py
+++ b/install.py
@@ -20,6 +20,7 @@ from PyQt6.QtWidgets import (
 )
 
 from . import __meta__, var
+from .collection_helpers import installerDefaultActionLabel, normalizedButtonLabel
 
 qDebug = var.debug
 
@@ -61,8 +62,7 @@ def installCollectionMetadata(metadata, parent=None):
 def clickButtonByText(widget, texts):
     wanted = {text.lower() for text in texts}
     for button in widget.findChildren(QPushButton):
-        label = button.text().replace("&", "").strip().lower()
-        if label in wanted and button.isEnabled():
+        if normalizedButtonLabel(button.text()) in wanted and button.isEnabled():
             suppressDialogAndClick(widget, button)
             return True
     return False
@@ -88,7 +88,7 @@ def acceptQuickInstallDialog():
                 return
 
         for button in widget.findChildren(QPushButton):
-            if button.text().replace("&", "").lower() == "ok" and button.isEnabled():
+            if normalizedButtonLabel(button.text()) == "ok" and button.isEnabled():
                 qDebug("[NXMColDL Install] Auto-accepting Quick Install dialog")
                 suppressDialogAndClick(widget, button)
                 return
@@ -118,7 +118,7 @@ def dismissKnownPostInstallErrorDialog(remaining=20):
                 return
 
         for button in widget.findChildren(QPushButton):
-            if button.text().replace("&", "").lower() == "ok" and button.isEnabled():
+            if normalizedButtonLabel(button.text()) == "ok" and button.isEnabled():
                 qDebug("[NXMColDL Install] Dismissing known post-install error dialog")
                 suppressDialogAndClick(widget, button)
                 return
@@ -134,6 +134,40 @@ def acceptModExistsDialog():
         if clickButtonByText(widget, ("Merge",)):
             qDebug("[NXMColDL Install] Auto-merging Mod Exists dialog")
             return
+
+
+def installerDefaultAction(widget):
+    """Return the safest default-action button for a visible FOMOD installer."""
+    if not widget.isVisible():
+        return None
+
+    buttons = widget.findChildren(QPushButton)
+    action = installerDefaultActionLabel(
+        widget.windowTitle(),
+        ((button.text(), button.isEnabled()) for button in buttons),
+    )
+    if action is None:
+        return None
+
+    for button in buttons:
+        if normalizedButtonLabel(button.text()) == action:
+            return button
+
+
+def advanceInstallerDialogDefaults():
+    for widget in QApplication.topLevelWidgets():
+        button = installerDefaultAction(widget)
+        if not button:
+            continue
+
+        qDebug(
+            "[NXMColDL Install] Auto-advancing installer defaults for "
+            f"{widget.windowTitle()}"
+        )
+        suppressDialogAndClick(widget, button)
+        return True
+
+    return False
 
 
 def scheduleInstallDialogHandlers(
@@ -377,6 +411,7 @@ class stepInstallMods(QDialog):
         self.install_warnings = []
         self.install_context = None
         self.cancel_requested = False
+        self.dialog_handler_generation = 0
 
         # Start installation after dialog is shown
         QTimer.singleShot(500, self.startInstallation)
@@ -588,6 +623,8 @@ class stepInstallMods(QDialog):
 
         log_path, log_offset = self.captureInterfaceLogPosition(organizer)
         try:
+            self.dialog_handler_generation += 1
+            dialog_handler_generation = self.dialog_handler_generation
             scheduleInstallDialogHandlers(
                 organizer.pluginSetting(
                     plugin_instance.name(), "auto_accept_quick_install"
@@ -600,6 +637,10 @@ class stepInstallMods(QDialog):
                     plugin_instance.name(), "auto_merge_existing_mods"
                 ),
             )
+            if organizer.pluginSetting(
+                plugin_instance.name(), "auto_advance_fomod_defaults"
+            ):
+                self.scheduleInstallerDefaultAdvancer(dialog_handler_generation)
 
             if context["separate_file_installs"]:
                 target_mod_name = self.allocateCollectionModName(
@@ -651,9 +692,24 @@ class stepInstallMods(QDialog):
         self.log("")
         QTimer.singleShot(1500, self.installNextMod)
 
+    def scheduleInstallerDefaultAdvancer(self, generation, remaining=240):
+        if remaining <= 0:
+            return
+        if generation != self.dialog_handler_generation:
+            return
+        if not self.install_context:
+            return
+
+        advanceInstallerDialogDefaults()
+        QTimer.singleShot(
+            250,
+            lambda: self.scheduleInstallerDefaultAdvancer(generation, remaining - 1),
+        )
+
     def finishInstallation(self, cancelled=False):
         if not self.install_context:
             return
+        self.dialog_handler_generation += 1
 
         context = self.install_context
         organizer = context["organizer"]

--- a/install.py
+++ b/install.py
@@ -2,7 +2,7 @@ import json
 from datetime import datetime
 from pathlib import Path
 
-from PyQt6.QtCore import Qt, QTimer, qDebug
+from PyQt6.QtCore import Qt, QTimer
 from PyQt6.QtWidgets import (
     QApplication,
     QDialogButtonBox,
@@ -19,6 +19,8 @@ from PyQt6.QtWidgets import (
 )
 
 from . import __meta__, var
+
+qDebug = var.debug
 
 MO2_WARNING_PATTERNS = (
     "Plugin not found:",

--- a/install.py
+++ b/install.py
@@ -26,6 +26,11 @@ MO2_WARNING_PATTERNS = (
     "[fomodinstallerdialog.cpp:",
 )
 
+EXPECTED_INSTALL_EXCEPTION_PATTERNS = (
+    "invalid origin name:",
+    "Plugin not found:",
+)
+
 
 def clickButtonByText(widget, texts):
     wanted = {text.lower() for text in texts}
@@ -411,6 +416,18 @@ class stepInstallMods(QDialog):
         qDebug(f"[NXMColDL Install] {message}")
         QApplication.processEvents()
 
+    def logInstallIssue(self, message, expected=False):
+        """Log install issues without making expected MO2 chatter look fatal."""
+        prefix = "NOTE" if expected else "ERROR"
+        level = "warning" if expected else "error"
+        self.log(f"  {prefix}: {message}", level)
+
+    def isExpectedInstallException(self, error):
+        message = str(error)
+        return any(
+            pattern in message for pattern in EXPECTED_INSTALL_EXCEPTION_PATTERNS
+        )
+
     def interfaceLogPath(self, organizer):
         return Path(organizer.downloadsPath()).parent / "logs" / "mo_interface.log"
 
@@ -533,7 +550,7 @@ class stepInstallMods(QDialog):
 
                 # Find downloaded file
                 if install_key not in download_map:
-                    self.log("  ERROR: Not found in downloads - skipping", "error")
+                    self.logInstallIssue("Not found in downloads - skipping")
                     self.log("")
                     continue
 
@@ -588,8 +605,8 @@ class stepInstallMods(QDialog):
                         if activate_after_install:
                             mods_to_activate.append(internal_name)
                     else:
-                        self.log(
-                            "  ERROR: Installation failed or was cancelled", "error"
+                        self.logInstallIssue(
+                            "Installation failed or was cancelled", expected=True
                         )
                 except Exception as e:
                     warning_count = self.collectInterfaceLogWarnings(
@@ -600,7 +617,10 @@ class stepInstallMods(QDialog):
                             f"  Captured {warning_count} MO2 warning(s) for report",
                             "warning",
                         )
-                    self.log(f"  ERROR: Installation error: {e}", "error")
+                    self.logInstallIssue(
+                        f"Installation issue: {e}",
+                        expected=self.isExpectedInstallException(e),
+                    )
 
                 self.log("")
 
@@ -612,10 +632,7 @@ class stepInstallMods(QDialog):
                     try:
                         modlist.setActive(internal_name, True)
                     except Exception as e:
-                        self.log(
-                            f"  ERROR: Could not activate {internal_name}: {e}",
-                            "error",
-                        )
+                        self.logInstallIssue(f"Could not activate {internal_name}: {e}")
                 warning_count = self.collectInterfaceLogWarnings(
                     log_path, log_offset, "post-install activation", ""
                 )

--- a/install.py
+++ b/install.py
@@ -256,19 +256,22 @@ class stepSelectCollection(QDialog):
             self.close()
             return
 
-        # Populate dropdown
+        # Populate dropdown with enough detail to distinguish concurrent
+        # collection downloads for the same game.
         for game, collection_id, revision, metadata_file in self.collections_list:
-            # Load metadata to get the display name
             try:
                 with open(metadata_file, "r", encoding="utf-8") as f:
                     metadata = json.load(f)
                     name = metadata.get("name", collection_id)
-                    # author = metadata.get("author", "Unknown")
-                    display_text = f"{name} (Rev {revision}) - {game}"
+                    total_mods = metadata.get("totalMods", "?")
+                    display_text = (
+                        f"{name} [{collection_id} rev {revision}, "
+                        f"{total_mods} mods] - {game}"
+                    )
                     self.dropdown.addItem(display_text)
             except Exception as e:
                 qDebug(f"[NXMColDL] Error loading metadata from {metadata_file}: {e}")
-                self.dropdown.addItem(f"{collection_id} (Rev {revision}) - {game}")
+                self.dropdown.addItem(f"{collection_id} [rev {revision}] - {game}")
 
         # Trigger initial selection
         if self.dropdown.count() > 0:
@@ -310,6 +313,8 @@ class stepSelectCollection(QDialog):
 				<br>
 				<br>
 				<b>Total Mods:</b> {total_mods}
+				<br>
+				<b>Collection:</b> {collection_id} rev {revision}
 				<br>
 				<b>Downloaded:</b> {timestamp.split("T")[0] if "T" in timestamp else timestamp}
 			""")

--- a/install.py
+++ b/install.py
@@ -1,9 +1,11 @@
 import json
+from datetime import datetime
 from pathlib import Path
 
 from PyQt6.QtCore import Qt, QTimer, qDebug
 from PyQt6.QtWidgets import (
     QApplication,
+    QDialogButtonBox,
     QComboBox,
     QDialog,
     QHBoxLayout,
@@ -17,6 +19,147 @@ from PyQt6.QtWidgets import (
 )
 
 from . import __meta__, var
+
+MO2_WARNING_PATTERNS = (
+    "Plugin not found:",
+    "invalid origin name:",
+    "[fomodinstallerdialog.cpp:",
+)
+
+
+def clickButtonByText(widget, texts):
+    wanted = {text.lower() for text in texts}
+    for button in widget.findChildren(QPushButton):
+        label = button.text().replace("&", "").strip().lower()
+        if label in wanted and button.isEnabled():
+            suppressDialogAndClick(widget, button)
+            return True
+    return False
+
+
+def suppressDialogAndClick(widget, button):
+    widget.setUpdatesEnabled(False)
+    widget.hide()
+    QApplication.processEvents()
+    button.click()
+
+
+def acceptQuickInstallDialog():
+    for widget in QApplication.topLevelWidgets():
+        if not widget.isVisible() or widget.windowTitle() != "Quick Install":
+            continue
+
+        for button_box in widget.findChildren(QDialogButtonBox):
+            button = button_box.button(QDialogButtonBox.StandardButton.Ok)
+            if button and button.isEnabled():
+                qDebug("[NXMColDL Install] Auto-accepting Quick Install dialog")
+                suppressDialogAndClick(widget, button)
+                return
+
+        for button in widget.findChildren(QPushButton):
+            if button.text().replace("&", "").lower() == "ok" and button.isEnabled():
+                qDebug("[NXMColDL Install] Auto-accepting Quick Install dialog")
+                suppressDialogAndClick(widget, button)
+                return
+
+
+def dismissKnownPostInstallErrorDialog(remaining=20):
+    if remaining <= 0:
+        return
+
+    for widget in QApplication.topLevelWidgets():
+        if not widget.isVisible() or widget.windowTitle() != "Error":
+            continue
+
+        labels = widget.findChildren(QLabel)
+        if not any(
+            "invalid origin name:" in label.text()
+            or "Plugin not found:" in label.text()
+            for label in labels
+        ):
+            continue
+
+        for button_box in widget.findChildren(QDialogButtonBox):
+            button = button_box.button(QDialogButtonBox.StandardButton.Ok)
+            if button and button.isEnabled():
+                qDebug("[NXMColDL Install] Dismissing known post-install error dialog")
+                suppressDialogAndClick(widget, button)
+                return
+
+        for button in widget.findChildren(QPushButton):
+            if button.text().replace("&", "").lower() == "ok" and button.isEnabled():
+                qDebug("[NXMColDL Install] Dismissing known post-install error dialog")
+                suppressDialogAndClick(widget, button)
+                return
+
+    QTimer.singleShot(250, lambda: dismissKnownPostInstallErrorDialog(remaining - 1))
+
+
+def acceptModExistsDialog():
+    for widget in QApplication.topLevelWidgets():
+        if not widget.isVisible() or widget.windowTitle() != "Mod Exists":
+            continue
+
+        if clickButtonByText(widget, ("Merge",)):
+            qDebug("[NXMColDL Install] Auto-merging Mod Exists dialog")
+            return
+
+
+def acceptDefaultInstallerDialog(remaining=80):
+    if remaining <= 0:
+        return
+
+    for widget in QApplication.topLevelWidgets():
+        if not widget.isVisible():
+            continue
+
+        title = widget.windowTitle()
+        if title in ("Error", "Quick Install") or title.startswith(
+            "NXM Collection Installer"
+        ):
+            continue
+
+        buttons = widget.findChildren(QPushButton)
+        button_by_text = {
+            button.text().replace("&", "").strip().lower(): button for button in buttons
+        }
+
+        # MO2 installer/FOMOD dialogs expose Next/Install buttons. Accept the
+        # already selected defaults, but do not click unrelated ordinary dialogs.
+        next_button = button_by_text.get("next")
+        install_button = button_by_text.get("install")
+        if next_button and next_button.isEnabled():
+            qDebug(f"[NXMColDL Install] Auto-accepting default installer page: {title}")
+            suppressDialogAndClick(widget, next_button)
+            QTimer.singleShot(300, lambda: acceptDefaultInstallerDialog(remaining - 1))
+            return
+
+        if install_button and install_button.isEnabled():
+            qDebug(
+                f"[NXMColDL Install] Auto-accepting default installer install: {title}"
+            )
+            suppressDialogAndClick(widget, install_button)
+            QTimer.singleShot(300, lambda: acceptDefaultInstallerDialog(remaining - 1))
+            return
+
+    QTimer.singleShot(300, lambda: acceptDefaultInstallerDialog(remaining - 1))
+
+
+def scheduleInstallDialogHandlers(
+    auto_accept_quick_install=True,
+    auto_dismiss_known_post_install_errors=True,
+    auto_accept_fomod_defaults=False,
+    auto_merge_existing_mods=True,
+):
+    for delay in (250, 750, 1500, 3000, 5000):
+        if auto_accept_quick_install:
+            QTimer.singleShot(delay, acceptQuickInstallDialog)
+        if auto_dismiss_known_post_install_errors:
+            QTimer.singleShot(delay, dismissKnownPostInstallErrorDialog)
+        if auto_merge_existing_mods:
+            QTimer.singleShot(delay, acceptModExistsDialog)
+    if auto_accept_fomod_defaults:
+        QTimer.singleShot(250, acceptDefaultInstallerDialog)
 
 
 class stepSelectCollection(QDialog):
@@ -250,6 +393,7 @@ class stepInstallMods(QDialog):
         layout.addWidget(self.close_btn)
 
         self.setLayout(layout)
+        self.install_warnings = []
 
         # Start installation after dialog is shown
         QTimer.singleShot(100, self.startInstallation)
@@ -266,6 +410,57 @@ class stepInstallMods(QDialog):
         self.log_text.append(f'<span style="color: {color};">{message}</span>')
         qDebug(f"[NXMColDL Install] {message}")
         QApplication.processEvents()
+
+    def interfaceLogPath(self, organizer):
+        return Path(organizer.downloadsPath()).parent / "logs" / "mo_interface.log"
+
+    def captureInterfaceLogPosition(self, organizer):
+        log_path = self.interfaceLogPath(organizer)
+        try:
+            return log_path, log_path.stat().st_size
+        except OSError:
+            return log_path, 0
+
+    def collectInterfaceLogWarnings(self, log_path, offset, mod_name, file_name):
+        captured = 0
+        try:
+            with open(log_path, "r", encoding="utf-8", errors="replace") as log_file:
+                log_file.seek(offset)
+                for line in log_file:
+                    line = line.rstrip()
+                    if not any(pattern in line for pattern in MO2_WARNING_PATTERNS):
+                        continue
+                    warning = {
+                        "mod": mod_name,
+                        "file": file_name,
+                        "message": line,
+                    }
+                    self.install_warnings.append(warning)
+                    captured += 1
+        except OSError as e:
+            qDebug(f"[NXMColDL Install] Could not read MO2 interface log: {e}")
+        return captured
+
+    def writeWarningReport(self, organizer):
+        if not self.install_warnings:
+            return None
+
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        report_path = (
+            self.interfaceLogPath(organizer).parent
+            / f"nxm-collection-install-warnings-{var.collection}-{var.revision}-{timestamp}.json"
+        )
+        report = {
+            "collection": var.collection,
+            "revision": var.revision,
+            "name": var.name,
+            "generated": datetime.now().isoformat(timespec="seconds"),
+            "warning_count": len(self.install_warnings),
+            "warnings": self.install_warnings,
+        }
+        with open(report_path, "w", encoding="utf-8") as report_file:
+            json.dump(report, report_file, indent=2)
+        return report_path
 
     def startInstallation(self):
         """Main installation process"""
@@ -301,10 +496,14 @@ class stepInstallMods(QDialog):
             # Build a mapping of (modId, fileId) -> download_path
             download_map = self.buildDownloadMap(downloads_path)
             self.log(f"Found {len(download_map)} downloaded files")
+
+            installed_map = self.buildInstalledMap(Path(organizer.modsPath()))
+            self.log(f"Found {len(installed_map)} installed Nexus file records")
             self.log("")
 
             # Install each mod in order
             installed_mods = []
+            mods_to_activate = []
             for idx, mod_info in enumerate(mods_to_install, 1):
                 self.progress_label.setText(
                     f"Installing mod {idx}/{len(mods_to_install)}"
@@ -319,42 +518,112 @@ class stepInstallMods(QDialog):
                 self.log(f"[{idx}/{len(mods_to_install)}] Processing: {mod_name}")
                 self.log(f"  File: {file_name} (ModID: {mod_id}, FileID: {file_id})")
 
+                install_key = (int(mod_id), int(file_id))
+                if install_key in installed_map:
+                    internal_name = installed_map[install_key]
+                    self.log(f"  Already installed as: {internal_name}", "success")
+                    self.log("")
+                    installed_mods.append(internal_name)
+                    activate_after_install = organizer.pluginSetting(
+                        plugin_instance.name(), "activate_mods_after_install"
+                    )
+                    if activate_after_install:
+                        mods_to_activate.append(internal_name)
+                    continue
+
                 # Find downloaded file
-                download_key = (int(mod_id), int(file_id))
-                if download_key not in download_map:
+                if install_key not in download_map:
                     self.log("  ERROR: Not found in downloads - skipping", "error")
                     self.log("")
                     continue
 
-                download_path = download_map[download_key]
+                download_path = download_map[install_key]
                 self.log(f"  Found: {download_path.name}")
 
                 # Install the mod
+                log_path, log_offset = self.captureInterfaceLogPosition(organizer)
                 try:
-                    installed_mod = organizer.installMod(str(download_path), mod_name)
+                    auto_accept_quick_install = organizer.pluginSetting(
+                        plugin_instance.name(), "auto_accept_quick_install"
+                    )
+                    auto_dismiss_known_post_install_errors = organizer.pluginSetting(
+                        plugin_instance.name(),
+                        "auto_dismiss_known_post_install_errors",
+                    )
+                    auto_accept_fomod_defaults = organizer.pluginSetting(
+                        plugin_instance.name(), "auto_accept_fomod_defaults"
+                    )
+                    auto_merge_existing_mods = organizer.pluginSetting(
+                        plugin_instance.name(), "auto_merge_existing_mods"
+                    )
+                    activate_after_install = organizer.pluginSetting(
+                        plugin_instance.name(), "activate_mods_after_install"
+                    )
+                    scheduleInstallDialogHandlers(
+                        auto_accept_quick_install,
+                        auto_dismiss_known_post_install_errors,
+                        auto_accept_fomod_defaults,
+                        auto_merge_existing_mods,
+                    )
+
+                    installed_mod = organizer.installMod(str(download_path))
+                    warning_count = self.collectInterfaceLogWarnings(
+                        log_path, log_offset, mod_name, file_name
+                    )
+                    if warning_count:
+                        self.log(
+                            f"  Captured {warning_count} MO2 warning(s) for report",
+                            "warning",
+                        )
                     if installed_mod:
                         internal_name = installed_mod.name()
-                        modlist.setActive(internal_name, True)
                         self.log(f"  Installed as: {internal_name}", "success")
 
-                        # Set priority to maintain collection order
-                        target_priority = base_priority + len(installed_mods)
-                        if modlist.setPriority(internal_name, target_priority):
-                            self.log(f"  Priority set to: {target_priority}", "success")
-                        else:
-                            self.log(
-                                f"  WARNING: Failed to set priority to {target_priority}",
-                                "warning",
-                            )
+                        self.log(
+                            "  Priority unchanged; MO2 appended the mod to the list",
+                            "warning",
+                        )
 
                         installed_mods.append(internal_name)
+                        if activate_after_install:
+                            mods_to_activate.append(internal_name)
                     else:
                         self.log(
                             "  ERROR: Installation failed or was cancelled", "error"
                         )
                 except Exception as e:
+                    warning_count = self.collectInterfaceLogWarnings(
+                        log_path, log_offset, mod_name, file_name
+                    )
+                    if warning_count:
+                        self.log(
+                            f"  Captured {warning_count} MO2 warning(s) for report",
+                            "warning",
+                        )
                     self.log(f"  ERROR: Installation error: {e}", "error")
 
+                self.log("")
+
+            if mods_to_activate:
+                self.progress_label.setText("Activating installed mods...")
+                self.log(f"Activating {len(mods_to_activate)} installed mods...")
+                log_path, log_offset = self.captureInterfaceLogPosition(organizer)
+                for internal_name in mods_to_activate:
+                    try:
+                        modlist.setActive(internal_name, True)
+                    except Exception as e:
+                        self.log(
+                            f"  ERROR: Could not activate {internal_name}: {e}",
+                            "error",
+                        )
+                warning_count = self.collectInterfaceLogWarnings(
+                    log_path, log_offset, "post-install activation", ""
+                )
+                if warning_count:
+                    self.log(
+                        f"  Captured {warning_count} MO2 warning(s) during activation",
+                        "warning",
+                    )
                 self.log("")
 
             # Final summary
@@ -365,6 +634,10 @@ class stepInstallMods(QDialog):
             self.log(f"  Total mods: {len(mods_to_install)}")
             self.log(f"  Successfully installed: {len(installed_mods)}")
             self.log(f"  Failed/Skipped: {len(mods_to_install) - len(installed_mods)}")
+            self.log(f"  MO2 warnings captured: {len(self.install_warnings)}")
+            report_path = self.writeWarningReport(organizer)
+            if report_path:
+                self.log(f"  Warning report: {report_path}", "warning")
             qDebug(
                 f"[NXMColDL] Installation complete: {len(installed_mods)}/{len(mods_to_install)} succeeded"
             )
@@ -399,6 +672,14 @@ class stepInstallMods(QDialog):
                 # Only consider files that exist and are not directories
                 if not download_file.exists() or download_file.is_dir():
                     continue
+                if download_file.name.endswith(".unfinished"):
+                    qDebug(
+                        f"[NXMColDL] Skipping unfinished download: {download_file.name}"
+                    )
+                    continue
+                if download_file.stat().st_size == 0:
+                    qDebug(f"[NXMColDL] Skipping empty download: {download_file.name}")
+                    continue
 
                 # Parse the .meta file (it's an INI-style file)
                 mod_id = None
@@ -429,3 +710,33 @@ class stepInstallMods(QDialog):
                 qDebug(f"[NXMColDL] Unexpected error parsing {meta_file.name}: {e}")
 
         return download_map
+
+    def buildInstalledMap(self, mods_path: Path):
+        installed_map = {}
+
+        if not mods_path.exists():
+            qDebug(f"[NXMColDL] Mods path not found: {mods_path}")
+            return installed_map
+
+        for meta_file in mods_path.glob("*/meta.ini"):
+            mod_id = None
+            file_ids = []
+            try:
+                with open(meta_file, "r", encoding="utf-8", errors="replace") as f:
+                    for line in f:
+                        line = line.strip()
+                        if line.startswith("modid="):
+                            mod_id = int(line.split("=", 1)[1])
+                        elif "\\fileid=" in line:
+                            file_ids.append(int(line.split("=", 1)[1]))
+
+                if mod_id is None:
+                    continue
+
+                for file_id in file_ids:
+                    installed_map[(mod_id, file_id)] = meta_file.parent.name
+
+            except (ValueError, IOError) as e:
+                qDebug(f"[NXMColDL] Error parsing installed metadata {meta_file}: {e}")
+
+        return installed_map

--- a/install.py
+++ b/install.py
@@ -35,6 +35,29 @@ EXPECTED_INSTALL_EXCEPTION_PATTERNS = (
 )
 
 
+def loadMetadataIntoVar(metadata):
+    """Load saved collection metadata into the module state used by installers."""
+    var.uri = metadata.get("uri")
+    var.game = metadata.get("game")
+    var.collection = metadata.get("collection")
+    var.revision = metadata.get("revision")
+    var.author = metadata.get("author", "Unknown Author")
+    var.name = metadata.get("name", "Unknown Collection")
+    var.summary = metadata.get("summary", "No description available.")
+    var.thumbnail = metadata.get("thumbnail")
+    var.essentialMods = metadata.get("essentialMods", [])
+    var.chosenOptional = metadata.get("chosenOptional", [])
+    var.externalMods = metadata.get("externalMods", [])
+
+
+def installCollectionMetadata(metadata, parent=None):
+    loadMetadataIntoVar(metadata)
+    qDebug(f"[NXMColDL] Loaded collection: {var.name}")
+    qDebug(f"[NXMColDL] Essential mods: {len(var.essentialMods)}")
+    qDebug(f"[NXMColDL] Optional mods: {len(var.chosenOptional)}")
+    stepInstallMods(parent).exec()
+
+
 def clickButtonByText(widget, texts):
     wanted = {text.lower() for text in texts}
     for button in widget.findChildren(QPushButton):
@@ -302,27 +325,8 @@ class stepSelectCollection(QDialog):
             QMessageBox.critical(self, "Error", "No collection selected")
             return
 
-        # Store metadata in var for use in subsequent steps
-        var.uri = self.current_metadata.get("uri")
-        var.game = self.current_metadata.get("game")
-        var.collection = self.current_metadata.get("collection")
-        var.revision = self.current_metadata.get("revision")
-        var.author = self.current_metadata.get("author", "Unknown Author")
-        var.name = self.current_metadata.get("name", "Unknown Collection")
-        var.summary = self.current_metadata.get("summary", "No description available.")
-        var.thumbnail = self.current_metadata.get("thumbnail")
-        var.essentialMods = self.current_metadata.get("essentialMods", [])
-        var.chosenOptional = self.current_metadata.get("chosenOptional", [])
-        var.externalMods = self.current_metadata.get("externalMods", [])
-
-        qDebug(f"[NXMColDL] Loaded collection: {var.name}")
-        qDebug(f"[NXMColDL] Essential mods: {len(var.essentialMods)}")
-        qDebug(f"[NXMColDL] Optional mods: {len(var.chosenOptional)}")
-
         self.close()
-
-        # Proceed to installation step
-        stepInstallMods(self.parent()).exec()
+        installCollectionMetadata(self.current_metadata, self.parent())
 
 
 class stepInstallMods(QDialog):

--- a/tests/test_collection_helpers.py
+++ b/tests/test_collection_helpers.py
@@ -1,0 +1,107 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from collection_helpers import (
+    downloadedFileKeys,
+    parseCollectionAddress,
+    unfinishedDownloadEntries,
+)
+
+
+class ParseCollectionAddressTests(unittest.TestCase):
+    def test_parses_nexus_collection_url_without_revision(self):
+        parsed = parseCollectionAddress(
+            "https://www.nexusmods.com/games/skyrimspecialedition/collections/8vdyr1"
+        )
+
+        self.assertEqual(
+            parsed,
+            {
+                "uri": "https://www.nexusmods.com/games/skyrimspecialedition/collections/8vdyr1",
+                "game": "skyrimspecialedition",
+                "collection": "8vdyr1",
+                "revision": None,
+            },
+        )
+
+    def test_parses_nexus_collection_url_with_revision(self):
+        parsed = parseCollectionAddress(
+            "https://www.nexusmods.com/games/skyrimspecialedition/collections/xxsqm4/revisions/99"
+        )
+
+        self.assertEqual(parsed["collection"], "xxsqm4")
+        self.assertEqual(parsed["revision"], 99)
+
+    def test_parses_nxm_collection_url(self):
+        parsed = parseCollectionAddress(
+            "nxm://skyrimspecialedition/collections/xxsqm4/revisions/99"
+        )
+
+        self.assertEqual(
+            parsed["uri"],
+            "https://www.nexusmods.com/games/skyrimspecialedition/collections/xxsqm4",
+        )
+        self.assertEqual(parsed["game"], "skyrimspecialedition")
+        self.assertEqual(parsed["collection"], "xxsqm4")
+        self.assertEqual(parsed["revision"], 99)
+
+    def test_rejects_non_collection_nxm_url(self):
+        self.assertIsNone(
+            parseCollectionAddress("nxm://skyrimspecialedition/mods/123/files/456")
+        )
+
+
+class DownloadedFileKeysTests(unittest.TestCase):
+    def test_returns_only_completed_archives_with_valid_metadata(self):
+        with TemporaryDirectory() as tmp:
+            downloads = Path(tmp)
+            archive = downloads / "Example Mod-123-456.7z"
+            archive.write_bytes(b"archive")
+            (downloads / "Example Mod-123-456.7z.meta").write_text(
+                "[General]\nmodID=123\nfileID=456\n", encoding="utf-8"
+            )
+
+            unfinished = downloads / "Partial Mod-111-222.7z.unfinished"
+            unfinished.write_bytes(b"partial")
+            (downloads / "Partial Mod-111-222.7z.unfinished.meta").write_text(
+                "[General]\nmodID=111\nfileID=222\n", encoding="utf-8"
+            )
+
+            missing_archive = downloads / "Missing Archive-333-444.7z.meta"
+            missing_archive.write_text(
+                "[General]\nmodID=333\nfileID=444\n", encoding="utf-8"
+            )
+
+            self.assertEqual(downloadedFileKeys(downloads), {(123, 456)})
+
+
+class UnfinishedDownloadEntriesTests(unittest.TestCase):
+    def test_returns_unfinished_archive_entries_by_nexus_key(self):
+        with TemporaryDirectory() as tmp:
+            downloads = Path(tmp)
+            archive = downloads / "Partial Mod-111-222.7z.unfinished"
+            archive.write_bytes(b"")
+            metadata = downloads / "Partial Mod-111-222.7z.unfinished.meta"
+            metadata.write_text("[General]\nmodID=111\nfileID=222\n", encoding="utf-8")
+
+            entries = unfinishedDownloadEntries(downloads)
+
+            self.assertEqual(set(entries), {(111, 222)})
+            self.assertEqual(entries[(111, 222)][0]["archive"], archive)
+            self.assertEqual(entries[(111, 222)][0]["metadata"], metadata)
+            self.assertEqual(entries[(111, 222)][0]["archive_size"], 0)
+
+    def test_ignores_unfinished_metadata_without_nexus_ids(self):
+        with TemporaryDirectory() as tmp:
+            downloads = Path(tmp)
+            (downloads / "Broken.7z.unfinished").write_bytes(b"")
+            (downloads / "Broken.7z.unfinished.meta").write_text(
+                "[General]\nmodID=bad\n", encoding="utf-8"
+            )
+
+            self.assertEqual(unfinishedDownloadEntries(downloads), {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_collection_helpers.py
+++ b/tests/test_collection_helpers.py
@@ -4,6 +4,8 @@ import unittest
 
 from collection_helpers import (
     downloadedFileKeys,
+    installerDefaultActionLabel,
+    normalizedButtonLabel,
     parseCollectionAddress,
     unfinishedDownloadEntries,
 )
@@ -101,6 +103,44 @@ class UnfinishedDownloadEntriesTests(unittest.TestCase):
             )
 
             self.assertEqual(unfinishedDownloadEntries(downloads), {})
+
+
+class InstallerDefaultActionLabelTests(unittest.TestCase):
+    def test_normalizes_decorated_button_labels(self):
+        self.assertEqual(normalizedButtonLabel("&Next >"), "next")
+        self.assertEqual(normalizedButtonLabel("< &Back"), "back")
+
+    def test_selects_enabled_next_on_fomod_dialog(self):
+        self.assertEqual(
+            installerDefaultActionLabel(
+                "Glorious Doors of Skyrim (GDOS) SE",
+                [("&Back", False), ("&Next >", True), ("Cancel", True)],
+            ),
+            "next",
+        )
+
+    def test_selects_enabled_install_on_final_fomod_page(self):
+        self.assertEqual(
+            installerDefaultActionLabel(
+                "UNP Female Body Renewal",
+                [("&Back", True), ("Install", True), ("Cancel", True)],
+            ),
+            "install",
+        )
+
+    def test_ignores_mo2_known_dialogs(self):
+        for title in ("Quick Install", "Mod Exists", "Error"):
+            self.assertIsNone(
+                installerDefaultActionLabel(
+                    title,
+                    [("Next", True), ("Install", True), ("Cancel", True)],
+                )
+            )
+
+    def test_requires_cancel_button_to_avoid_generic_next_prompts(self):
+        self.assertIsNone(
+            installerDefaultActionLabel("NXM Collection Link Handler", [("Next", True)])
+        )
 
 
 if __name__ == "__main__":

--- a/var.py
+++ b/var.py
@@ -153,4 +153,13 @@ def listCollectionMetadata(base_path: Path):
                     )
                     continue
 
-    return collections
+    def metadata_sort_key(collection_info):
+        metadata_file = collection_info[3]
+        try:
+            with open(metadata_file, "r", encoding="utf-8") as f:
+                metadata = json.load(f)
+            return metadata.get("timestamp") or metadata_file.stat().st_mtime
+        except Exception:
+            return metadata_file.stat().st_mtime
+
+    return sorted(collections, key=metadata_sort_key, reverse=True)

--- a/var.py
+++ b/var.py
@@ -2,7 +2,7 @@ import json
 import re
 from pathlib import Path
 from datetime import datetime
-from PyQt6.QtCore import qDebug, QUrl
+from PyQt6.QtCore import QUrl, qDebug as _qDebug
 from PyQt6.QtGui import QPixmap
 from PyQt6.QtCore import Qt
 from PyQt6.QtNetwork import QNetworkAccessManager, QNetworkRequest, QNetworkReply
@@ -24,6 +24,15 @@ bundledMods = []
 chosenOptional = []
 chosenExternal = True
 openModWebsites = False
+
+
+def debug(message):
+    """Send text to MO2's debug log without crashing on non-ASCII Nexus data."""
+    safe_message = str(message).encode("ascii", "backslashreplace").decode("ascii")
+    _qDebug(safe_message)
+
+
+qDebug = debug
 
 
 def cleanJson(data, visible=False):


### PR DESCRIPTION
## Summary
- add an opt-in installer setting to advance FOMOD dialogs using their currently selected defaults
- keep the dialog classifier conservative so known MO2 prompts are ignored
- add unit tests for button-label normalization and FOMOD action selection

## Dependency
Stacked on #15, which is stacked on #14 and #13.

## Testing
- ruff format --check .
- ruff check .
- python -m unittest discover -s tests
- python -m py_compile __init__.py __meta__.py download.py install.py var.py api.py collection_helpers.py